### PR TITLE
Add FLUENT_ELASTICSEARCH_SCHEME environment variable

### DIFF
--- a/docker-image/v0.12/elasticsearch/conf/fluent.conf
+++ b/docker-image/v0.12/elasticsearch/conf/fluent.conf
@@ -9,6 +9,7 @@
    include_tag_key true
    host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
    port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
+   scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
    logstash_format true
    buffer_chunk_limit 2M
    buffer_queue_limit 32

--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -23,6 +23,8 @@ spec:
             value: "elasticsearch-logging"
           - name:  FLUENT_ELASTICSEARCH_PORT
             value: "9200"
+          - name: FLUENT_ELASTICSEARCH_SCHEME
+            value: "http"
         resources:
           limits:
             memory: 200Mi

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -12,6 +12,7 @@
    include_tag_key true
    host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
    port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
+   scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
    logstash_format true
    buffer_chunk_limit 2M
    buffer_queue_limit 32


### PR DESCRIPTION
AWS elasticsearch runs on port `443`, hence requires the scheme to be `https`.