### PR TITLE
update fluent-kubernetes-daemonset image location

### DIFF
--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: fluentd
-        image: quay.io/fluent/fluentd-kubernetes-daemonset
+        image: fluent/fluentd-kubernetes-daemonset:elasticsearch
         env:
           - name:  FLUENT_ELASTICSEARCH_HOST
             value: "elasticsearch-logging"


### PR DESCRIPTION
The version on quay.io is old and not versioned, and seems to have problems with ES 5.x. This one on hub.docker.com is newer (and has tags for things other than just Elasticsearch) includes a much newer "elasticsearch" rubygem.

This should help with https://github.com/fluent/fluentd-kubernetes-daemonset/issues/11.