### PR TITLE
Add toleration to allow fluentd to run on masters

### DIFF
--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -15,6 +15,9 @@ spec:
         version: v1
         kubernetes.io/cluster-service: "true"
     spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
       containers:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:elasticsearch


### PR DESCRIPTION
Kubernetes 1.6 now has a taint on all the masters called "node-role.kubernetes.io/master" effect: NoSchedule, Which means without adding the toleration for this, Any DaemonSets will not run on masters. This PR adds this toleration to the fluentd daemonset.