### PR TITLE
Use newer version of fluent-plugin-cloudwatch-logs

### DIFF
--- a/docker-image/v0.12/alpine-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/alpine-cloudwatch/Dockerfile
@@ -15,7 +15,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
-    && gem install fluent-plugin-cloudwatch-logs -v 0.3.3 \
+    && gem install fluent-plugin-cloudwatch-logs -v 0.3.4 \
     && gem install fluent-plugin-kubernetes_metadata_filter \
     && apk del .build-deps \
     && gem sources --clear-all \

--- a/docker-image/v0.12/debian-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/debian-cloudwatch/Dockerfile
@@ -16,7 +16,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
-    && gem install fluent-plugin-cloudwatch-logs -v 0.3.3 \
+    && gem install fluent-plugin-cloudwatch-logs -v 0.3.4 \
     && gem install fluent-plugin-kubernetes_metadata_filter \
     && gem install ffi \
     && gem install fluent-plugin-systemd -v 0.0.8 \


### PR DESCRIPTION
By bumping the version we get rid of this [problem](https://github.com/ryotarai/fluent-plugin-cloudwatch-logs/pull/36).