### PR TITLE
Add moreoptions for elasticsearch config

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -19,6 +19,8 @@
    scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
    user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
+   reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
+   logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
    buffer_chunk_limit 2M
    buffer_queue_limit 32


### PR DESCRIPTION
Hey,

I'm proposing a pull request that just allows people to have a more customized setup with you docker image.

If you need me to create an issue for this please tell me.

Info:
Added two configs for elasticsearch:
* reload_connections: Adding this as possible env variable will allow people that use AWS ES to disable the feature. I know there is a separate plugin for aws, but I'd like to stick with the original ES plugin. Adding this is a quick win for most people and doesn't interfere with how it works today
* logstash_prefix: Another quick win allowing to customize the indexes used by fluent for ES