### PR TITLE
Mmake ES user/password inclusion conditional

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -17,8 +17,12 @@
    host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
    port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
    scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
+   <% if ENV.key?('FLUENT_ELASTICSEARCH_USER') %>
    user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
+   <% end %>
+   <% if ENV.key?('FLUENT_ELASTICSEARCH_PASSWORD') %>
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
+   <% end %>
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true


### PR DESCRIPTION
This commit makes the elasticsearch user & password configuration lines conditional. I discovered a bug using AWS ElasticSearch service. They do not include a username/password. Omitting the FLUENT_ELASTICSEARCH_{USER,PASSWORD} environment variables on the DaemonSet generates blank lines in the generated files which end up as empty values. The result is HTTP authentication is used even when environment variables are not set. This is a workaround for possible issue in the elasticsearch output plugin.