### PR TITLE
Fix version of aws sdk to v2.10.50 for CloudWatch image

### DIFF
--- a/docker-image/v0.12/alpine-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/alpine-cloudwatch/Dockerfile
@@ -15,6 +15,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install aws-sdk-core -v 2.10.50 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \
     && gem install fluent-plugin-kubernetes_metadata_filter \
     && apk del .build-deps \

--- a/docker-image/v0.12/debian-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/debian-cloudwatch/Dockerfile
@@ -16,6 +16,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install aws-sdk-core -v 2.10.50 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \
     && gem install fluent-plugin-kubernetes_metadata_filter \
     && gem install ffi \

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -38,6 +38,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
 <% when "loggly"%>
     && gem install fluent-plugin-loggly \
 <% when "cloudwatch"%>
+    && gem install aws-sdk-core -v 2.10.50 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \
 <% when "stackdriver" %>
     && gem install fluent-plugin-google-cloud \


### PR DESCRIPTION
This fixes #50.

`fluent-plugin-cloudwatch-logs` has a dependency on `aws-sdk-core` >= 2.0.7. The newest versions 3.x are not backwards compatible, so we fix the dependency to the latest 2.x release (2.10.50).

As noted on the original issue, when pushed to docker hub, there should be a version of each image that is not updated so that docker images that are based on them are not updated implicitly. I haven't made these changes in this pull request, as I don't know how you want to manage this.