### PR TITLE
Add support for custom Loggly tags

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -41,7 +41,7 @@
 <match **>
    type loggly
    log_level info
-   loggly_url "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/fluentd"
+   loggly_url "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}"
 </match>
 <%  when "cloudwatch"%>
 <match **>


### PR DESCRIPTION
**Custom Loggly Tags**

This pull request allows Loggly users to customize how their logs are tagged. Inside issue #57, I describe why this functionality might be useful:

> I'd like to add multiple tags to logs that are sent from Fluentd to Loggly. With the current Fluentd configuration, Loggly logs are only tagged as `fleuntd` and I don't have the option to add my own tags.



The proposed change enables someone to provide Fluentd with a list of custom tags. Fluentd will tag all Loggly logs according to the list of given tags. Alternatively, if no custom tags are provided, all logs are tagged as `fluentd` by default (to reflect the current behavior).