### PR TITLE
Added missing configuration information for S3 output

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -52,8 +52,20 @@
 </match>
 <%  when "s3"%>
 <match **>
+  # docs: https://docs.fluentd.org/v0.12/articles/out_s3
   type s3
+  log_level info
   s3_bucket "#{ENV['S3_BUCKET_NAME']}"
+  s3_region "#{ENV['S3_BUCKET_REGION']}"
+  s3_object_key_format %{path}%{time_slice}/cluster-log-%{index}.%{file_extension}
+  buffer_path "#{ENV['S3_BUFFER_PATH']}"
+  time_slice_format %Y/%m/%d
+  time_slice_wait 10m
+  utc
+  include_time_key true
+  include_tag_key true
+  buffer_chunk_limit 256m
+  buffer_path /var/log/fluentd-buffers/s3.buffer
 </match>
 <% when "stackdriver"%>
 <match **>

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -53,12 +53,12 @@
 <%  when "s3"%>
 <match **>
   # docs: https://docs.fluentd.org/v0.12/articles/out_s3
+  # note: this configuration relies on the nodes have an IAM instance profile with access to your S3 bucket
   type s3
   log_level info
   s3_bucket "#{ENV['S3_BUCKET_NAME']}"
   s3_region "#{ENV['S3_BUCKET_REGION']}"
   s3_object_key_format %{path}%{time_slice}/cluster-log-%{index}.%{file_extension}
-  buffer_path "#{ENV['S3_BUFFER_PATH']}"
   time_slice_format %Y/%m/%d
   time_slice_wait 10m
   utc


### PR DESCRIPTION
Looks like the S3 provider currently only has the bucket name as part of it's configuration. Fluentd won't even start without a buffer path and S3 region being specified so I've gone ahead and added those plus some sane defaults.