### PR TITLE
elasticsearch plugin for fluentd 0.12.x

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -34,7 +34,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
 <% case target when "elasticsearch"%>
-    && gem install fluent-plugin-elasticsearch \
+    && gem install fluent-plugin-elasticsearch -v "<2" \
 <% when "logentries"%>
     # && gem install fluent-plugin-logentries \
 <% when "loggly"%>


### PR DESCRIPTION
v2.0.0 and up require 0.14.x or greater, but v1.x of the plugin maintains compatibility with 0.12

fixes https://github.com/fluent/fluentd-kubernetes-daemonset/issues/69