### PR TITLE
Fix shebang as tests won't work with sh

### DIFF
--- a/docker-image/v0.12/alpine-cloudwatch/entrypoint.sh
+++ b/docker-image/v0.12/alpine-cloudwatch/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/alpine-elasticsearch/entrypoint.sh
+++ b/docker-image/v0.12/alpine-elasticsearch/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/alpine-logentries/entrypoint.sh
+++ b/docker-image/v0.12/alpine-logentries/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/alpine-loggly/entrypoint.sh
+++ b/docker-image/v0.12/alpine-loggly/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/alpine-papertrail/entrypoint.sh
+++ b/docker-image/v0.12/alpine-papertrail/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/alpine-s3/entrypoint.sh
+++ b/docker-image/v0.12/alpine-s3/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/debian-cloudwatch/entrypoint.sh
+++ b/docker-image/v0.12/debian-cloudwatch/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/debian-elasticsearch/entrypoint.sh
+++ b/docker-image/v0.12/debian-elasticsearch/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/debian-logentries/entrypoint.sh
+++ b/docker-image/v0.12/debian-logentries/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/debian-loggly/entrypoint.sh
+++ b/docker-image/v0.12/debian-loggly/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/debian-papertrail/entrypoint.sh
+++ b/docker-image/v0.12/debian-papertrail/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/debian-s3/entrypoint.sh
+++ b/docker-image/v0.12/debian-s3/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/docker-image/v0.12/debian-stackdriver/entrypoint.sh
+++ b/docker-image/v0.12/debian-stackdriver/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 

--- a/templates/entrypoint.sh
+++ b/templates/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 set -e
 


### PR DESCRIPTION
Executing `/fluentd/entrypoint.sh` throws the following errors because `sh` doesn't know the '[[' construct:

```
/fluentd/entrypoint.sh: 5: /fluentd/entrypoint.sh: [[: not found
/fluentd/entrypoint.sh: 9: /fluentd/entrypoint.sh: [[: not found
```
Changing the shebang to `bash` fixes this.