### PR TITLE
Add exception detection plugin to elastic version

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -35,6 +35,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && gem install fluent-plugin-record-reformer \
 <% case target when "elasticsearch"%>
     && gem install fluent-plugin-elasticsearch \
+    && gem install fluent-plugin-detect-exceptions \
 <% when "logentries"%>
     # && gem install fluent-plugin-logentries \
 <% when "loggly"%>


### PR DESCRIPTION
Elastic works better if stacktrace errors are passed together instead of having each line separately.