### PR TITLE
Environment variable to configure SSL certificate validatation

### DIFF
--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -28,6 +28,10 @@ spec:
             value: "9200"
           - name: FLUENT_ELASTICSEARCH_SCHEME
             value: "http"
+          # Option to configure Secure Forward Plugin with self signed certs
+          # ================================================================
+          - name: FLUENT_ELASTICSEARCH_SECURE
+            value: "true"
           # X-Pack Authentication
           # =====================
           - name: FLUENT_ELASTICSEARCH_USER

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -17,6 +17,7 @@
    host "#{ENV['FLUENT_ELASTICSEARCH_HOST']}"
    port "#{ENV['FLUENT_ELASTICSEARCH_PORT']}"
    scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
+   secure "#{ENV['FLUENT_ELASTICSEARCH_SECURE'] || 'true'}"
    user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"


### PR DESCRIPTION
My user case is the following:
- AWS Elasticsearch domain is deployed and it has a valid SSL certificate
- AWS ES endpoint is registered in a discovery service (Consul)
- Fluentd is deployed in K8s using discovery service DNS
- Fluentd fails forwarding logs to because of the SSL certificate error
`2018-03-21 10:13:22 +0000 [warn]: #0 failed to flush the buffer. retry_time=558 next_retry_seconds=2018-03-21 10:13:53 +0000 chunk="567e8c7455e79d2bdeefb8160f963926" error_class=Faraday::SSLError...`

Secure forward plugin is provided
https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v0.12/alpine-elasticsearch/Dockerfile#L17

Plugin documentation
https://github.com/tagomoris/fluent-plugin-secure-forward#using-insecure-self-signed-certificates