### PR TITLE
Update aws-sdk-core to v2.11.31

### DIFF
--- a/docker-image/v0.12/alpine-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/alpine-cloudwatch/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
-    && gem install aws-sdk-core -v 2.10.50 \
+    && gem install aws-sdk-core -v 2.11.31 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \
     && gem install fluent-plugin-kubernetes_metadata_filter \
     && apk del .build-deps \

--- a/docker-image/v0.12/debian-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/debian-cloudwatch/Dockerfile
@@ -18,7 +18,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
-    && gem install aws-sdk-core -v 2.10.50 \
+    && gem install aws-sdk-core -v 2.11.31 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \
     && gem install fluent-plugin-kubernetes_metadata_filter \
     && gem install ffi \

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -45,7 +45,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev<% case target when
 <% when "loggly"%>
     && gem install fluent-plugin-loggly \
 <% when "cloudwatch"%>
-    && gem install aws-sdk-core -v 2.10.50 \
+    && gem install aws-sdk-core -v 2.11.31 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \
 <% when "stackdriver" %>
     && gem install fluent-plugin-google-cloud \


### PR DESCRIPTION
Upgrade aws-sdk-core to latest.

the latest version of ruby is ​​raise error when contain CR/LF in iniheader of initialize_http_headerr(https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/61359).
the latest version of aws-sdk-core solved that problem.