### PR TITLE
Fix missing Graylog tag and add Graylog RBAC example

### DIFF
--- a/docker-image/v0.12/alpine-graylog/conf/fluent.conf
+++ b/docker-image/v0.12/alpine-graylog/conf/fluent.conf
@@ -16,4 +16,5 @@
    max_retry_wait 30
    disable_retry_limit
    num_threads 8
+</match>
 

--- a/fluentd-daemonset-graylog-rbac.yaml
+++ b/fluentd-daemonset-graylog-rbac.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluentd
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: fluentd
+roleRef:
+  kind: ClusterRole
+  name: fluentd
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: kube-system
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+    spec:
+      serviceAccount: fluentd
+      serviceAccountName: fluentd
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: fluentd
+        imagePullPolicy: Always
+        image: fluent/fluentd-kubernetes-daemonset:graylog
+        env:
+          - name:  FLUENT_GRAYLOG_HOST
+            value: "graylog-host"
+          - name:  FLUENT_GRAYLOG_PORT
+            value: "12201"
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -120,6 +120,7 @@
    max_retry_wait 30
    disable_retry_limit
    num_threads 8
+</match>
 <% when "logzio"%>
 <match **>
   type logzio_buffered


### PR DESCRIPTION
This commit features a minor change - adding a missing </match> tag to the Graylog configuration.

It also has an example Graylog DaemonSet configuration with RBAC enabled. Unlike "elasticsearch-rbac" it does not include:

- kubernetes.io/cluster-service: "true"

Whilst testing this on a GKE cluster, the inclusion of this resulted in it always being killed off after under a minute with the message "Killing container with id docker://fluentd:Need to kill Pod"