### PR TITLE
Add the fluent-plugin-rewrite-tag-filter

### DIFF
--- a/docker-image/v0.12/alpine-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/alpine-cloudwatch/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install aws-sdk-core -v 2.10.50 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-elasticsearch/Dockerfile
+++ b/docker-image/v0.12/alpine-elasticsearch/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-elasticsearch -v "<2" \
     && gem install fluent-plugin-kubernetes_metadata_filter \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && apk del .build-deps \
     && gem sources --clear-all \
     && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem

--- a/docker-image/v0.12/alpine-gcs/Dockerfile
+++ b/docker-image/v0.12/alpine-gcs/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-gcs -v "~> 0.3"  --no-document \
     && gem install fluent-plugin-kubernetes_metadata_filter \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && apk del .build-deps \
     && gem sources --clear-all \
     && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem

--- a/docker-image/v0.12/alpine-graylog/Dockerfile
+++ b/docker-image/v0.12/alpine-graylog/Dockerfile
@@ -18,6 +18,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install jeweler \
     && git clone https://github.com/graylog-labs/gelf-rb.git \

--- a/docker-image/v0.12/alpine-kafka/Dockerfile
+++ b/docker-image/v0.12/alpine-kafka/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-kafka \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-logentries/Dockerfile
+++ b/docker-image/v0.12/alpine-logentries/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     # && gem install fluent-plugin-logentries \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-loggly/Dockerfile
+++ b/docker-image/v0.12/alpine-loggly/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-loggly \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-logzio/Dockerfile
+++ b/docker-image/v0.12/alpine-logzio/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-logzio \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-papertrail/Dockerfile
+++ b/docker-image/v0.12/alpine-papertrail/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-papertrail -v 0.1.1 \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-s3/Dockerfile
+++ b/docker-image/v0.12/alpine-s3/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-s3 -v "~> 0.8" \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-stackdriver/Dockerfile
+++ b/docker-image/v0.12/alpine-stackdriver/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-google-cloud \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/alpine-syslog/Dockerfile
+++ b/docker-image/v0.12/alpine-syslog/Dockerfile
@@ -16,6 +16,7 @@ RUN set -ex \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install specific_install \
     && gem specific_install -l https://github.com/georgegoh/fluent-plugin-kubernetes_remote_syslog.git \

--- a/docker-image/v0.12/debian-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/debian-cloudwatch/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install aws-sdk-core -v 2.10.50 \
     && gem install fluent-plugin-cloudwatch-logs -v 0.4.0 \

--- a/docker-image/v0.12/debian-elasticsearch/Dockerfile
+++ b/docker-image/v0.12/debian-elasticsearch/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-elasticsearch -v "<2" \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-gcs/Dockerfile
+++ b/docker-image/v0.12/debian-gcs/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-gcs -v "~> 0.3"  --no-document \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-graylog/Dockerfile
+++ b/docker-image/v0.12/debian-graylog/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev git build-essentia
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install jeweler \
     && git clone https://github.com/graylog-labs/gelf-rb.git \

--- a/docker-image/v0.12/debian-kafka/Dockerfile
+++ b/docker-image/v0.12/debian-kafka/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-kafka \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-logentries/Dockerfile
+++ b/docker-image/v0.12/debian-logentries/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     # && gem install fluent-plugin-logentries \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-loggly/Dockerfile
+++ b/docker-image/v0.12/debian-loggly/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-loggly \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-logzio/Dockerfile
+++ b/docker-image/v0.12/debian-logzio/Dockerfile
@@ -16,6 +16,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-logzio \
     && gem install fluent-plugin-kubernetes_metadata_filter \
     && gem install ffi \

--- a/docker-image/v0.12/debian-papertrail/Dockerfile
+++ b/docker-image/v0.12/debian-papertrail/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-papertrail -v 0.1.1 \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-s3/Dockerfile
+++ b/docker-image/v0.12/debian-s3/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-s3 -v "~> 0.8" \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-stackdriver/Dockerfile
+++ b/docker-image/v0.12/debian-stackdriver/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install fluent-plugin-google-cloud \
     && gem install fluent-plugin-kubernetes_metadata_filter \

--- a/docker-image/v0.12/debian-syslog/Dockerfile
+++ b/docker-image/v0.12/debian-syslog/Dockerfile
@@ -17,6 +17,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev ruby-dev libffi-dev" \
     && echo 'gem: --no-document' >> /etc/gemrc \
     && gem install fluent-plugin-secure-forward \
     && gem install fluent-plugin-record-reformer \
+    && gem install fluent-plugin-rewrite-tag-filter \
     && gem install fluent-plugin-detect-exceptions -v 0.0.9 \
     && gem install specific_install \
     && gem specific_install -l https://github.com/georgegoh/fluent-plugin-kubernetes_remote_syslog.git \


### PR DESCRIPTION
We use this to strip off the "kubernetes.var.log.containers." prefix