### PR TITLE
added aws_key_id and aws_sec_key into config template

### DIFF
--- a/docker-image/v0.12/alpine-s3/conf/fluent.conf
+++ b/docker-image/v0.12/alpine-s3/conf/fluent.conf
@@ -6,7 +6,7 @@
 
 <match **>
   # docs: https://docs.fluentd.org/v0.12/articles/out_s3
-  # note: this configuration relies on the nodes have an IAM instance profile with access to your S3 bucket
+  # note: Make sure you use secrets to store your AWS key/secret
   type s3
   log_level info
   s3_bucket "#{ENV['S3_BUCKET_NAME']}"

--- a/docker-image/v0.12/alpine-s3/conf/fluent.conf
+++ b/docker-image/v0.12/alpine-s3/conf/fluent.conf
@@ -11,6 +11,8 @@
   log_level info
   s3_bucket "#{ENV['S3_BUCKET_NAME']}"
   s3_region "#{ENV['S3_BUCKET_REGION']}"
+  aws_key_id "#{ENV['AWS_KEY_ID']}"
+  aws_sec_key "#{ENV['AWS_SEC_KEY']}"
   s3_object_key_format %{path}%{time_slice}/cluster-log-%{index}.%{file_extension}
   time_slice_format %Y/%m/%d
   time_slice_wait 10m

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -54,7 +54,7 @@
 <%  when "s3"%>
 <match **>
   # docs: https://docs.fluentd.org/v0.12/articles/out_s3
-  # note: this configuration relies on the nodes have an IAM instance profile with access to your S3 bucket
+  # note: Make sure you use secrets to store your AWS key/secret
   type s3
   log_level info
   s3_bucket "#{ENV['S3_BUCKET_NAME']}"

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -59,6 +59,8 @@
   log_level info
   s3_bucket "#{ENV['S3_BUCKET_NAME']}"
   s3_region "#{ENV['S3_BUCKET_REGION']}"
+  aws_key_id "#{ENV['AWS_KEY_ID']}"
+  aws_sec_key "#{ENV['AWS_SEC_KEY']}"
   s3_object_key_format %{path}%{time_slice}/cluster-log-%{index}.%{file_extension}
   time_slice_format %Y/%m/%d
   time_slice_wait 10m


### PR DESCRIPTION
We shouldn't be relying on IAM roles on the EC2 host to filter down to the container. With RBAC this make it tricky. It seems much simpler to simply set up the key and secret as secrets in k8s then pull them into the daemonset like so:

```
apiVersion: extensions/v1beta1
kind: DaemonSet
metadata:
  name: fluentd
  namespace: default
  labels:
    app: fluentd
spec:
  selector:
    matchLabels:
      name: fluentd-s3
  template:
    metadata:
      labels:
        name: fluentd-s3
    spec:
      containers:
      - name: fluentd
        image: vect0r/fluentd-kubernetes-daemonset:latest
        env:
          - name: S3_BUCKET_NAME
            value: "test1"
          - name: S3_BUCKET_REGION
            value: "eu-central-1"
          - name: AWS_KEY_ID
            valueFrom:
              secretKeyRef:
                name: secret-s3
                key: secret_access_s3
          - name: AWS_SEC_KEY
            valueFrom:
              secretKeyRef:
                name: secret-s3
                key: secret_key_s3
        ports:
          - containerPort: 24220
      serviceAccountName: fluentd
```