### PR TITLE
Use Loggly's bulk endpoint

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -45,7 +45,7 @@
    @type loggly
    @id out_loggly
    log_level info
-   loggly_url "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}"
+   loggly_url "https://logs-01.loggly.com/bulk/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}/bulk"
 </match>
 <%  when "cloudwatch"%>
 <match **>


### PR DESCRIPTION
Not sure how common this is but I was getting a lot of "Error connecting to loggly please check your url"

Following the KBs noted in [this forum post](https://community.loggly.com/customer/portal/questions/16719622-getting-error-connecting-to-loggly-verify-the-url) switching to the bulk endpoint has made these errors appear much less frequently. For further reading, see this [Loggly KB](https://www.loggly.com/docs/http-bulk-endpoint/)

