### PR TITLE
Fix fluent user issue

### DIFF
--- a/docker-image/v1.1/debian-cloudwatch/Dockerfile
+++ b/docker-image/v1.1/debian-cloudwatch/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-cloudwatch/Gemfile.lock
+++ b/docker-image/v1.1/debian-cloudwatch/Gemfile.lock
@@ -88,7 +88,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -102,4 +102,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-elasticsearch/Dockerfile
+++ b/docker-image/v1.1/debian-elasticsearch/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-elasticsearch/Gemfile.lock
+++ b/docker-image/v1.1/debian-elasticsearch/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -105,4 +105,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-gcs/Dockerfile
+++ b/docker-image/v1.1/debian-gcs/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-gcs/Gemfile.lock
+++ b/docker-image/v1.1/debian-gcs/Gemfile.lock
@@ -127,7 +127,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -140,4 +140,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-graylog/Dockerfile
+++ b/docker-image/v1.1/debian-graylog/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-graylog/Gemfile.lock
+++ b/docker-image/v1.1/debian-graylog/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -100,4 +100,4 @@ DEPENDENCIES
   gelf!
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-kafka/Dockerfile
+++ b/docker-image/v1.1/debian-kafka/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-kafka/Gemfile.lock
+++ b/docker-image/v1.1/debian-kafka/Gemfile.lock
@@ -81,7 +81,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -94,4 +94,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-logentries/Dockerfile
+++ b/docker-image/v1.1/debian-logentries/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-logentries/Gemfile.lock
+++ b/docker-image/v1.1/debian-logentries/Gemfile.lock
@@ -75,7 +75,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -87,4 +87,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-loggly/Dockerfile
+++ b/docker-image/v1.1/debian-loggly/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-loggly/Gemfile.lock
+++ b/docker-image/v1.1/debian-loggly/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -92,4 +92,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-loggly/conf/fluent.conf
+++ b/docker-image/v1.1/debian-loggly/conf/fluent.conf
@@ -9,5 +9,5 @@
    @type loggly
    @id out_loggly
    log_level info
-   loggly_url "https://logs-01.loggly.com/inputs/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}"
+   loggly_url "https://logs-01.loggly.com/bulk/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}/bulk"
 </match>

--- a/docker-image/v1.1/debian-logzio/Dockerfile
+++ b/docker-image/v1.1/debian-logzio/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-papertrail/Dockerfile
+++ b/docker-image/v1.1/debian-papertrail/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-papertrail/Gemfile.lock
+++ b/docker-image/v1.1/debian-papertrail/Gemfile.lock
@@ -84,7 +84,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     uuidtools (2.1.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -97,4 +97,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-s3/Dockerfile
+++ b/docker-image/v1.1/debian-s3/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-s3/Gemfile.lock
+++ b/docker-image/v1.1/debian-s3/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -110,4 +110,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-stackdriver/Dockerfile
+++ b/docker-image/v1.1/debian-stackdriver/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-stackdriver/Gemfile.lock
+++ b/docker-image/v1.1/debian-stackdriver/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.7.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -137,4 +137,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/docker-image/v1.1/debian-syslog/Dockerfile
+++ b/docker-image/v1.1/debian-syslog/Dockerfile
@@ -46,5 +46,8 @@ ENV FLUENTD_CONF="fluent.conf"
 # See https://packages.debian.org/stretch/amd64/libjemalloc1/filelist
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]

--- a/docker-image/v1.1/debian-syslog/Gemfile.lock
+++ b/docker-image/v1.1/debian-syslog/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.5)
     uuidtools (2.1.5)
-    yajl-ruby (1.3.1)
+    yajl-ruby (1.4.0)
 
 PLATFORMS
   ruby
@@ -112,4 +112,4 @@ DEPENDENCIES
   fluentd (= 1.1.3)
 
 BUNDLED WITH
-   1.14.3
+   1.16.1

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -89,5 +89,10 @@ ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.1"
 #ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2"
 <% end %>
 
+<% if is_v1 %>
+# Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
+ENTRYPOINT ["/fluentd/entrypoint.sh"]
+<% end %>
+
 # Run Fluentd
 CMD ["/fluentd/entrypoint.sh"]


### PR DESCRIPTION
To fix permission issue with `fluent` user.
Use micdah's approach.
Adding group by monotek is impossible because parent image creates `fluent` user in `entrypoint.sh`.