### PR TITLE
Configures the systemd plugin for elasticsearch

### DIFF
--- a/docker-image/v0.12/alpine-elasticsearch/conf/systemd.conf
+++ b/docker-image/v0.12/alpine-elasticsearch/conf/systemd.conf
@@ -8,6 +8,7 @@
   @id in_systemd_kubelet
   filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
   pos_file /var/log/fluentd-journald-kubelet.pos
+  strip_underscores true
   read_from_head true
   tag kubelet
 </source>
@@ -18,6 +19,7 @@
   @id in_systemd_docker
   filters [{ "_SYSTEMD_UNIT": "docker.service" }]
   pos_file /var/log/fluentd-journald-docker.pos
+  strip_underscores true
   read_from_head true
   tag docker.systemd
 </source>
@@ -28,6 +30,7 @@
   @id in_systemd_bootkube
   filters [{ "_SYSTEMD_UNIT": "bootkube.service" }]
   pos_file /var/log/fluentd-journald-bootkube.pos
+  strip_underscores true
   read_from_head true
   tag bootkube
 </source>

--- a/docker-image/v0.12/debian-elasticsearch/conf/systemd.conf
+++ b/docker-image/v0.12/debian-elasticsearch/conf/systemd.conf
@@ -8,6 +8,7 @@
   @id in_systemd_kubelet
   filters [{ "_SYSTEMD_UNIT": "kubelet.service" }]
   pos_file /var/log/fluentd-journald-kubelet.pos
+  strip_underscores true
   read_from_head true
   tag kubelet
 </source>
@@ -18,6 +19,7 @@
   @id in_systemd_docker
   filters [{ "_SYSTEMD_UNIT": "docker.service" }]
   pos_file /var/log/fluentd-journald-docker.pos
+  strip_underscores true
   read_from_head true
   tag docker.systemd
 </source>
@@ -28,6 +30,7 @@
   @id in_systemd_bootkube
   filters [{ "_SYSTEMD_UNIT": "bootkube.service" }]
   pos_file /var/log/fluentd-journald-bootkube.pos
+  strip_underscores true
   read_from_head true
   tag bootkube
 </source>

--- a/docker-image/v1.1/debian-elasticsearch/conf/systemd.conf
+++ b/docker-image/v1.1/debian-elasticsearch/conf/systemd.conf
@@ -12,6 +12,9 @@
     persistent true
     path /var/log/fluentd-journald-kubelet-cursor.json
   </storage>
+  <entry>
+    fields_strip_underscores true
+  </entry>
   read_from_head true
   tag kubelet
 </source>
@@ -26,6 +29,9 @@
     persistent true
     path /var/log/fluentd-journald-docker-cursor.json
   </storage>
+  <entry>
+    fields_strip_underscores true
+  </entry>
   read_from_head true
   tag docker.systemd
 </source>
@@ -40,6 +46,9 @@
     persistent true
     path /var/log/fluentd-journald-bootkube-cursor.json
   </storage>
+  <entry>
+    fields_strip_underscores true
+  </entry>
   read_from_head true
   tag bootkube
 </source>

--- a/templates/conf/systemd.conf.erb
+++ b/templates/conf/systemd.conf.erb
@@ -15,8 +15,16 @@
     persistent true
     path /var/log/fluentd-journald-kubelet-cursor.json
   </storage>
+<% if target == "elasticsearch" %>
+  <entry>
+    fields_strip_underscores true
+  </entry>
+<% end %>
 <% else %>
   pos_file /var/log/fluentd-journald-kubelet.pos
+<% if target == "elasticsearch" %>
+  strip_underscores true
+<% end %>
 <% end %>
   read_from_head true
   tag kubelet
@@ -33,8 +41,16 @@
     persistent true
     path /var/log/fluentd-journald-docker-cursor.json
   </storage>
+<% if target == "elasticsearch" %>
+  <entry>
+    fields_strip_underscores true
+  </entry>
+<% end %>
 <% else %>
   pos_file /var/log/fluentd-journald-docker.pos
+<% if target == "elasticsearch" %>
+  strip_underscores true
+<% end %>
 <% end %>
   read_from_head true
   tag docker.systemd
@@ -51,8 +67,16 @@
     persistent true
     path /var/log/fluentd-journald-bootkube-cursor.json
   </storage>
+<% if target == "elasticsearch" %>
+  <entry>
+    fields_strip_underscores true
+  </entry>
+<% end %>
 <% else %>
   pos_file /var/log/fluentd-journald-bootkube.pos
+<% if target == "elasticsearch" %>
+  strip_underscores true
+<% end %>
 <% end %>
   read_from_head true
   tag bootkube


### PR DESCRIPTION
* Systemd fields are all prefixed with an underscore
* Kibana ignores fields prefixed with an underscore: see https://github.com/elastic/kibana/issues/2551

This change configures the systemd plugin to remove the leading
underscore from systemd fields when pushing to elasticsearch.