### PR TITLE
Bump fluent-plugin-systemd

### DIFF
--- a/docker-image/v0.12/debian-cloudwatch/Gemfile.lock
+++ b/docker-image/v0.12/debian-cloudwatch/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-mixin-config-placeholders (0.4.0)
       fluentd
       uuidtools (>= 2.1.5)
@@ -34,9 +34,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -83,7 +83,7 @@ GEM
       netrc (~> 0.8)
     sigdump (0.2.4)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -111,4 +111,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-elasticsearch/Gemfile.lock
+++ b/docker-image/v0.12/debian-elasticsearch/Gemfile.lock
@@ -23,8 +23,8 @@ GEM
     excon (0.62.0)
     faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
     fluent-plugin-elasticsearch (1.16.0)
+    ffi (1.9.25)
       elasticsearch
       excon
       fluentd (>= 0.12.10)
@@ -38,9 +38,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -88,12 +88,12 @@ GEM
       netrc (~> 0.8)
     sigdump (0.2.4)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.4)
+    tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -114,4 +114,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-gcs/Gemfile.lock
+++ b/docker-image/v0.12/debian-gcs/Gemfile.lock
@@ -15,7 +15,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-gcs (0.3.0)
       fluentd (~> 0.12.0)
       google-cloud-storage (~> 0.23.2)
@@ -29,9 +29,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -118,12 +118,12 @@ GEM
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.4)
+    tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
     uber (0.0.15)
     unf (0.1.4)
@@ -145,4 +145,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-graylog/Gemfile.lock
+++ b/docker-image/v0.12/debian-graylog/Gemfile.lock
@@ -19,8 +19,8 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
     fluent-plugin-gelf-hs (1.0.6)
+    ffi (1.9.25)
       fluentd
       gelf (>= 2.0.0)
     fluent-plugin-kubernetes_metadata_filter (1.0.2)
@@ -33,9 +33,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -81,12 +81,12 @@ GEM
       netrc (~> 0.8)
     sigdump (0.2.4)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.4)
+    tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -108,4 +108,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-kafka/Gemfile.lock
+++ b/docker-image/v0.12/debian-kafka/Gemfile.lock
@@ -12,8 +12,8 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
     fluent-plugin-kafka (0.7.2)
+    ffi (1.9.25)
       fluentd (>= 0.10.58, < 2)
       ltsv
       ruby-kafka (>= 0.4.1, < 1.0.0)
@@ -27,9 +27,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -103,4 +103,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-logentries/Gemfile.lock
+++ b/docker-image/v0.12/debian-logentries/Gemfile.lock
@@ -12,8 +12,8 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
     fluent-plugin-kubernetes_metadata_filter (1.0.2)
+    ffi (1.9.25)
       fluentd (>= 0.12.0)
       kubeclient (~> 1.1.4)
       lru_redux
@@ -23,9 +23,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -71,7 +71,7 @@ GEM
       netrc (~> 0.8)
     sigdump (0.2.4)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -96,4 +96,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-loggly/Gemfile.lock
+++ b/docker-image/v0.12/debian-loggly/Gemfile.lock
@@ -12,8 +12,8 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
     fluent-plugin-kubernetes_metadata_filter (1.0.2)
+    ffi (1.9.25)
       fluentd (>= 0.12.0)
       kubeclient (~> 1.1.4)
       lru_redux
@@ -26,9 +26,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -75,7 +75,7 @@ GEM
       netrc (~> 0.8)
     sigdump (0.2.4)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -101,4 +101,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-logzio/Gemfile.lock
+++ b/docker-image/v0.12/debian-logzio/Gemfile.lock
@@ -12,8 +12,8 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
     fluent-plugin-kubernetes_metadata_filter (1.0.2)
+    ffi (1.9.25)
       fluentd (>= 0.12.0)
       kubeclient (~> 1.1.4)
       lru_redux
@@ -26,9 +26,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -75,7 +75,7 @@ GEM
       netrc (~> 0.8)
     sigdump (0.2.4)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -101,4 +101,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-papertrail/Gemfile.lock
+++ b/docker-image/v0.12/debian-papertrail/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-mixin-config-placeholders (0.4.0)
       fluentd
       uuidtools (>= 2.1.5)
@@ -30,9 +30,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -79,12 +79,12 @@ GEM
     sigdump (0.2.4)
     string-scrub (0.0.5)
     syslog_protocol (0.9.2)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    tzinfo-data (1.2018.4)
+    tzinfo-data (1.2018.5)
       tzinfo (>= 1.0.0)
     unf (0.1.4)
       unf_ext
@@ -106,4 +106,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-s3/Gemfile.lock
+++ b/docker-image/v0.12/debian-s3/Gemfile.lock
@@ -20,8 +20,8 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
     fluent-plugin-kubernetes_metadata_filter (1.0.2)
+    ffi (1.9.25)
       fluentd (>= 0.12.0)
       kubeclient (~> 1.1.4)
       lru_redux
@@ -34,9 +34,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -83,7 +83,7 @@ GEM
       netrc (~> 0.8)
     sigdump (0.2.4)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -109,4 +109,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-stackdriver/Gemfile.lock
+++ b/docker-image/v0.12/debian-stackdriver/Gemfile.lock
@@ -16,8 +16,8 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     faraday (0.15.0)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
     fluent-plugin-google-cloud (0.6.18)
+    ffi (1.9.25)
       fluentd (~> 0.10)
       google-api-client (~> 0.17)
       google-cloud-logging (~> 1.3, >= 1.3.2)
@@ -35,9 +35,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -146,7 +146,7 @@ GEM
     stackdriver-core (1.3.0)
       google-cloud-core (~> 1.2)
     string-scrub (0.0.5)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -173,4 +173,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v0.12/debian-syslog/Gemfile.lock
+++ b/docker-image/v0.12/debian-syslog/Gemfile.lock
@@ -12,7 +12,7 @@ GEM
     cool.io (1.5.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-mixin-config-placeholders (0.4.0)
       fluentd
       uuidtools (>= 2.1.5)
@@ -37,9 +37,9 @@ GEM
       fluentd (>= 0.10.46)
       proxifier
       resolve-hostname
-    fluent-plugin-systemd (0.0.10)
+    fluent-plugin-systemd (0.0.11)
       fluentd (~> 0.12)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (0.12.33)
       cool.io (>= 1.2.2, < 2.0.0)
       http_parser.rb (>= 0.5.1, < 0.7.0)
@@ -89,7 +89,7 @@ GEM
     sigdump (0.2.4)
     string-scrub (0.0.5)
     syslog_protocol (0.9.2)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -116,4 +116,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-cloudwatch/Gemfile.lock
+++ b/docker-image/v1.2/debian-cloudwatch/Gemfile.lock
@@ -24,7 +24,7 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-cloudwatch-logs (0.5.0)
       aws-sdk-cloudwatchlogs (~> 1.0)
       fluentd (>= 0.14.15)
@@ -32,9 +32,9 @@ GEM
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -81,7 +81,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -106,4 +106,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-elasticsearch/Gemfile.lock
+++ b/docker-image/v1.2/debian-elasticsearch/Gemfile.lock
@@ -24,8 +24,8 @@ GEM
     excon (0.62.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
     fluent-plugin-elasticsearch (2.10.1)
+    ffi (1.9.25)
       elasticsearch
       excon
       fluentd (>= 0.14.20)
@@ -33,9 +33,9 @@ GEM
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -83,7 +83,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -107,4 +107,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-gcs/Gemfile.lock
+++ b/docker-image/v1.2/debian-gcs/Gemfile.lock
@@ -18,7 +18,7 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-gcs (0.4.0.beta1)
       fluentd (>= 0.14.0, < 2)
       google-cloud-storage (~> 1.1.0)
@@ -26,9 +26,9 @@ GEM
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -117,7 +117,7 @@ GEM
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -142,4 +142,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-graylog/Gemfile.lock
+++ b/docker-image/v1.2/debian-graylog/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-gelf-hs (1.0.7)
       fluentd
       gelf (>= 2.0.0)
@@ -21,9 +21,9 @@ GEM
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -72,7 +72,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -97,4 +97,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-kafka/Gemfile.lock
+++ b/docker-image/v1.2/debian-kafka/Gemfile.lock
@@ -13,8 +13,8 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
     fluent-plugin-kafka (0.7.2)
+    ffi (1.9.25)
       fluentd (>= 0.10.58, < 2)
       ltsv
       ruby-kafka (>= 0.4.1, < 1.0.0)
@@ -22,9 +22,9 @@ GEM
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -72,7 +72,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -96,4 +96,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-logentries/Gemfile.lock
+++ b/docker-image/v1.2/debian-logentries/Gemfile.lock
@@ -13,14 +13,14 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-kubernetes_metadata_filter (2.1.2)
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -66,7 +66,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -89,4 +89,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-loggly/Gemfile.lock
+++ b/docker-image/v1.2/debian-loggly/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-kubernetes_metadata_filter (2.1.2)
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
@@ -21,9 +21,9 @@ GEM
     fluent-plugin-loggly (0.0.9)
       net-http-persistent (~> 2.7)
       yajl-ruby (~> 1.0)
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -70,7 +70,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -94,4 +94,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-logzio/Gemfile.lock
+++ b/docker-image/v1.2/debian-logzio/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-kubernetes_metadata_filter (2.1.2)
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
@@ -21,9 +21,9 @@ GEM
     fluent-plugin-logzio (0.0.16)
       fluentd (>= 0.14.0, < 2)
       net-http-persistent (~> 2.9)
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -70,7 +70,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -94,4 +94,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-papertrail/Gemfile.lock
+++ b/docker-image/v1.2/debian-papertrail/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-mixin-config-placeholders (0.4.0)
       fluentd
       uuidtools (>= 2.1.5)
@@ -25,9 +25,9 @@ GEM
       fluent-mixin-config-placeholders (~> 0.4.0)
       fluentd (>= 0.10, < 2)
       syslog_protocol
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -74,7 +74,7 @@ GEM
     sigdump (0.2.4)
     strptime (0.2.3)
     syslog_protocol (0.9.2)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -99,4 +99,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-s3/Gemfile.lock
+++ b/docker-image/v1.2/debian-s3/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-kubernetes_metadata_filter (2.1.2)
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
@@ -40,9 +40,9 @@ GEM
       aws-sdk-s3 (~> 1.0)
       aws-sdk-sqs (~> 1.0)
       fluentd (>= 0.14.2, < 2)
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -89,7 +89,7 @@ GEM
       sigdump (~> 0.2.2)
     sigdump (0.2.4)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -114,4 +114,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-stackdriver/Gemfile.lock
+++ b/docker-image/v1.2/debian-stackdriver/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     extlib (0.9.16)
     faraday (0.15.2)
       multipart-post (>= 1.2, < 3)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-plugin-google-cloud (0.4.10)
       fluentd (>= 0.10)
       google-api-client (~> 0.8.6)
@@ -30,9 +30,9 @@ GEM
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -115,7 +115,7 @@ GEM
       jwt (>= 1.5, < 3.0)
       multi_json (~> 1.10)
     strptime (0.2.3)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -139,4 +139,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2

--- a/docker-image/v1.2/debian-syslog/Gemfile.lock
+++ b/docker-image/v1.2/debian-syslog/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     dig_rb (1.0.1)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    ffi (1.9.23)
+    ffi (1.9.25)
     fluent-mixin-config-placeholders (0.4.0)
       fluentd
       uuidtools (>= 2.1.5)
@@ -32,9 +32,9 @@ GEM
       fluent-mixin-rewrite-tag-name
       fluentd
       remote_syslog_sender (~> 1.2.1)
-    fluent-plugin-systemd (1.0.0)
+    fluent-plugin-systemd (1.0.1)
       fluentd (>= 0.14.11, < 2)
-      systemd-journal (~> 1.3)
+      systemd-journal (~> 1.3.2)
     fluentd (1.2.1)
       cool.io (>= 1.4.5, < 2.0.0)
       dig_rb (~> 1.0.0)
@@ -84,7 +84,7 @@ GEM
     sigdump (0.2.4)
     strptime (0.2.3)
     syslog_protocol (0.9.2)
-    systemd-journal (1.3.1)
+    systemd-journal (1.3.2)
       ffi (~> 1.9)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
@@ -109,4 +109,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
Pulls in version 1.0.1 or 0.0.11  (for v0.12) of fluent-plugin-systemd

See https://github.com/reevoo/fluent-plugin-systemd/pull/65 for more
info about the issue that it fixes.

This may manifest in journal files not being correctly deleted by
some versions of systemd after they have been rotated.

FYI there are some other plugin updates that show up when running `make gemfile-all`... I did not include them in this PR...