### PR TITLE
adding datadog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ IMAGE_NAME := fluent/fluentd-kubernetes
 ALL_IMAGES := \
 	v1.3/debian-elasticsearch:v1.3.3-debian-elasticsearch-1.1,v1.3-debian-elasticsearch-1 \
 	v1.3/debian-loggly:v1.3.3-debian-loggly-1.0,v1.3-debian-loggly-1 \
+    v1.3/debian-datadog:v1.3.3-debian-datadog-1.0,v1.3-debian-datadog-1 \
 	v1.3/debian-logentries:v1.3.3-debian-logentries-1.0,v1.3-debian-logentries-1 \
 	v1.3/debian-cloudwatch:v1.3.3-debian-cloudwatch-1.1,v1.3-debian-cloudwatch-1 \
 	v1.3/debian-stackdriver:v1.3.3-debian-stackdriver-1.0,v1.3-debian-stackdriver-1 \

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 
 - `v1.3.3-debian-elasticsearch-1.1,v1.3-debian-elasticsearch-1` [docker-image/v1.3/debian-elasticsearch/Dockerfile](docker-image/v1.3/debian-elasticsearch/Dockerfile)
 - `v1.3.3-debian-loggly-1.0,v1.3-debian-loggly-1` [docker-image/v1.3/debian-loggly/Dockerfile](docker-image/v1.3/debian-loggly/Dockerfile)
+- `v1.3.3-debian-datadog-1.0,v1.3-debian-loggly-1` [docker-image/v1.3/debian-datadog/Dockerfile](docker-image/v1.3/debian-datadog/Dockerfile)
 - `v1.3.3-debian-logentries-1.0,v1.3-debian-logentries-1` [docker-image/v1.3/debian-logentries/Dockerfile](docker-image/v1.3/debian-logentries/Dockerfile)
 - `v1.3.3-debian-cloudwatch-1.1,v1.3-debian-cloudwatch-1` [docker-image/v1.3/debian-cloudwatch/Dockerfile](docker-image/v1.3/debian-cloudwatch/Dockerfile)
 - `v1.3.3-debian-stackdriver-1.0,v1.3-debian-stackdriver-1` [docker-image/v1.3/debian-stackdriver/Dockerfile](docker-image/v1.3/debian-stackdriver/Dockerfile)
@@ -44,6 +45,7 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 
 - `v0.12-alpine-elasticsearch` [docker-image/v0.12/alpine-elasticsearch/Dockerfile](docker-image/v0.12/alpine-elasticsearch/Dockerfile)
 - `v0.12-alpine-loggly` [docker-image/v0.12/alpine-loggly/Dockerfile](docker-image/v0.12/alpine-loggly/Dockerfile)
+- `v0.12-alpine-datadog` [docker-image/v0.12/alpine-datadog/Dockerfile](docker-image/v0.12/alpine-datadog/Dockerfile)
 - `v0.12-alpine-logentries` [docker-image/v0.12/alpine-logentries/Dockerfile](docker-image/v0.12/alpine-logentries/Dockerfile)
 - `v0.12-alpine-cloudwatch` [docker-image/v0.12/alpine-cloudwatch/Dockerfile](docker-image/v0.12/alpine-cloudwatch/Dockerfile)
 - `v0.12-alpine-stackdriver` [docker-image/v0.12/alpine-stackdriver/Dockerfile](docker-image/v0.12/alpine-stackdriver/Dockerfile)

--- a/fluentd-daemonset-datadog.yaml
+++ b/fluentd-daemonset-datadog.yaml
@@ -1,0 +1,56 @@
+## Datadog example Daemonset
+
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: fluentd
+  namespace: kube-system
+  labels:
+    k8s-app: fluentd-logging
+    version: v1
+    kubernetes.io/cluster-service: "true"
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: fluentd-logging
+        version: v1
+        kubernetes.io/cluster-service: "true"
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      containers:
+      - name: fluentd
+        image: fluent/fluentd-kubernetes-daemonset:datadog
+        env:
+          - name: DATADOG_API_KEY
+            value: "XXXX"
+          - name: DATADOG_TAGS
+            value: "cluster:example,env:example"
+          - name: DATADOG_SOURCE
+            value: "fluentd"
+          - name: DATADOG_SOURCE_CATEGORY
+            value: "k8s"
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: varlog
+          mountPath: /var/log
+        - name: varlibdockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: varlibdockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -30,6 +30,8 @@ gem "fluent-plugin-loggly", "~> 0.0.9"
 <% else %>
 gem "fluent-plugin-loggly"
 <% end %>
+<% when "datadog"%>
+gem "fluent-plugin-datadog"
 <% when "cloudwatch" %>
 gem "aws-sdk-cloudwatchlogs", "~> 1.0"
 <% if is_v1 %>

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -63,6 +63,18 @@
    @log_level info
    loggly_url "https://logs-01.loggly.com/bulk/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}/bulk"
 </match>
+<%  when "datadog"%>
+<match **>
+   @type datadog
+   @id out_datadog
+   log_level info
+   api_key "#{ENV['DATADOG_API_KEY']}"
+   include_tag_key true
+   tag_key 'tag'
+   dd_source "#{ENV['DATADOG_SOURCE'] || 'fluentd'}"
+   dd_tags "#{ENV['DATADOG_TAGS'] || 'fluentd:fluentd'}"
+   dd_sourcecategory "#{ENV['DATADOG_SOURCE_CATEGORY'] || 'fluentd'}"
+</match>
 <%  when "cloudwatch"%>
 <match **>
   @type cloudwatch_logs


### PR DESCRIPTION
I've added datadog support.  Hopefully I've followed the established pattern correctly. I see fluent/fluentd-kubernetes-daemonset/pull/85 exists but attempted to edit the outputs instead of the templates, this PR edited the templates.