### PR TITLE
fix(dumb-init) Upgrade base image version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,30 +12,30 @@
 
 IMAGE_NAME := fluent/fluentd-kubernetes
 ALL_IMAGES := \
-	v0.12/alpine-elasticsearch:v0.12.33-elasticsearch,v0.12-elasticsearch,stable-elasticsearch,elasticsearch \
-	v0.12/alpine-loggly:v0.12.33-loggly,v0.12-loggly,stable-loggly,loggly \
-	v0.12/alpine-logentries:v0.12.33-logentries,v0.12-logentries,stable-logentries,logentries \
-	v0.12/alpine-cloudwatch:v0.12.33-cloudwatch,v0.12-cloudwatch,stable-cloudwatch,cloudwatch \
-	v0.12/alpine-stackdriver:v0.12.33-stackdriver,v0.12-alpine-stackdriver,stable-stackdriver,stackdriver \
-	v0.12/alpine-s3:v0.12.33-s3,v0.12-s3,stable-s3,s3 \
-	v0.12/alpine-gcs:v0.12.33-gcs,v0.12-gcs,stable-gcs,gcs \
-	v0.12/alpine-papertrail:v0.12.33-papertrail,v0.12-papertrail,stable-papertrail,papertrail \
-	v0.12/alpine-syslog:v0.12.33-syslog,v0.12-syslog,stable-syslog,syslog \
-	v0.12/alpine-graylog:v0.12.33-graylog,v0.12-graylog,stable-graylog,graylog \
-	v0.12/alpine-logzio:v0.12.33-logzio,v0.12-logzio,stable-logzio,logzio \
-	v0.12/alpine-kafka:v0.12.33-kafka,v0.12-kafka,stable-kafka,kafka \
-	v0.12/debian-elasticsearch:v0.12.33-debian-elasticsearch,v0.12-debian-elasticsearch,debian-elasticsearch \
-	v0.12/debian-loggly:v0.12.33-debian-loggly,v0.12-debian-loggly,debian-loggly \
-	v0.12/debian-logentries:v0.12.33-debian-logentries,v0.12-debian-logentries,debian-logentries \
-	v0.12/debian-cloudwatch:v0.12.33-debian-cloudwatch,v0.12-debian-cloudwatch,debian-cloudwatch \
-	v0.12/debian-stackdriver:v0.12.33-debian-stackdriver,v0.12-debian-stackdriver,debian-stackdriver \
-	v0.12/debian-s3:v0.12.33-debian-s3,v0.12-debian-s3,debian-s3 \
-	v0.12/debian-gcs:v0.12.33-debian-gcs,v0.12-debian-gcs,debian-gcs \
-	v0.12/debian-papertrail:v0.12.33-debian-papertrail,v0.12-debian-papertrail,debian-papertrail \
-	v0.12/debian-syslog:v0.12.33-debian-syslog,v0.12-debian-syslog,debian-syslog \
-	v0.12/debian-graylog:v0.12.33-debian-graylog,v0.12-debian-graylog,debian-stable-graylog,debian-graylog \
-	v0.12/debian-logzio:v0.12.33-debian-logzio,v0.12-debian-logzio,debian-logzio \
-	v0.12/debian-kafka:v0.12.33-debian-kafka,v0.12-debian-kafka,debian-kafka \
+	v0.12/alpine-elasticsearch:v0.12.43-elasticsearch,v0.12-elasticsearch,stable-elasticsearch,elasticsearch \
+	v0.12/alpine-loggly:v0.12.43-loggly,v0.12-loggly,stable-loggly,loggly \
+	v0.12/alpine-logentries:v0.12.43-logentries,v0.12-logentries,stable-logentries,logentries \
+	v0.12/alpine-cloudwatch:v0.12.43-cloudwatch,v0.12-cloudwatch,stable-cloudwatch,cloudwatch \
+	v0.12/alpine-stackdriver:v0.12.43-stackdriver,v0.12-alpine-stackdriver,stable-stackdriver,stackdriver \
+	v0.12/alpine-s3:v0.12.43-s3,v0.12-s3,stable-s3,s3 \
+	v0.12/alpine-gcs:v0.12.43-gcs,v0.12-gcs,stable-gcs,gcs \
+	v0.12/alpine-papertrail:v0.12.43-papertrail,v0.12-papertrail,stable-papertrail,papertrail \
+	v0.12/alpine-syslog:v0.12.43-syslog,v0.12-syslog,stable-syslog,syslog \
+	v0.12/alpine-graylog:v0.12.43-graylog,v0.12-graylog,stable-graylog,graylog \
+	v0.12/alpine-logzio:v0.12.43-logzio,v0.12-logzio,stable-logzio,logzio \
+	v0.12/alpine-kafka:v0.12.43-kafka,v0.12-kafka,stable-kafka,kafka \
+	v0.12/debian-elasticsearch:v0.12.43-debian-elasticsearch,v0.12-debian-elasticsearch,debian-elasticsearch \
+	v0.12/debian-loggly:v0.12.43-debian-loggly,v0.12-debian-loggly,debian-loggly \
+	v0.12/debian-logentries:v0.12.43-debian-logentries,v0.12-debian-logentries,debian-logentries \
+	v0.12/debian-cloudwatch:v0.12.43-debian-cloudwatch,v0.12-debian-cloudwatch,debian-cloudwatch \
+	v0.12/debian-stackdriver:v0.12.43-debian-stackdriver,v0.12-debian-stackdriver,debian-stackdriver \
+	v0.12/debian-s3:v0.12.43-debian-s3,v0.12-debian-s3,debian-s3 \
+	v0.12/debian-gcs:v0.12.43-debian-gcs,v0.12-debian-gcs,debian-gcs \
+	v0.12/debian-papertrail:v0.12.43-debian-papertrail,v0.12-debian-papertrail,debian-papertrail \
+	v0.12/debian-syslog:v0.12.43-debian-syslog,v0.12-debian-syslog,debian-syslog \
+	v0.12/debian-graylog:v0.12.43-debian-graylog,v0.12-debian-graylog,debian-stable-graylog,debian-graylog \
+	v0.12/debian-logzio:v0.12.43-debian-logzio,v0.12-debian-logzio,debian-logzio \
+	v0.12/debian-kafka:v0.12.43-debian-kafka,v0.12-debian-kafka,debian-kafka \
 	v1.2/debian-elasticsearch:v1.2.2-debian-elasticsearch,v1.2-debian-elasticsearch \
 	v1.2/debian-loggly:v1.2.2-debian-loggly,v1.2-debian-loggly \
 	v1.2/debian-logentries:v1.2.2-debian-logentries,v1.2-debian-logentries \

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -15,9 +15,15 @@ FROM fluent/fluentd:<%= fluentd_ver %>-debian
 LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
 USER root
 WORKDIR /home/fluent
+<% if is_alpine %>
 ENV PATH /fluentd/vendor/bundle/ruby/2.4.0/bin:$PATH
 ENV GEM_PATH /fluentd/vendor/bundle/ruby/2.4.0
 ENV GEM_HOME /fluentd/vendor/bundle/ruby/2.4.0
+<% else %>
+ENV PATH /fluentd/vendor/bundle/ruby/2.3.0/bin:$PATH
+ENV GEM_PATH /fluentd/vendor/bundle/ruby/2.3.0
+ENV GEM_HOME /fluentd/vendor/bundle/ruby/2.3.0
+<% end %>
 # skip runtime bundler installation
 ENV FLUENTD_DISABLE_BUNDLER_INJECTION 1
 

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -15,9 +15,9 @@ FROM fluent/fluentd:<%= fluentd_ver %>-debian
 LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"
 USER root
 WORKDIR /home/fluent
-ENV PATH /fluentd/vendor/bundle/ruby/2.3.0/bin:$PATH
-ENV GEM_PATH /fluentd/vendor/bundle/ruby/2.3.0
-ENV GEM_HOME /fluentd/vendor/bundle/ruby/2.3.0
+ENV PATH /fluentd/vendor/bundle/ruby/2.4.0/bin:$PATH
+ENV GEM_PATH /fluentd/vendor/bundle/ruby/2.4.0
+ENV GEM_HOME /fluentd/vendor/bundle/ruby/2.4.0
 # skip runtime bundler installation
 ENV FLUENTD_DISABLE_BUNDLER_INJECTION 1
 


### PR DESCRIPTION
The latest version of the `entrypoint.sh` on this repo uses `dumb-init`
which has been included on fluentd/fluentd:v0.12.43 but not on v0.12.33

Github issue #164 

`Dockerfile`s and `Gemfile.lock` need to be regenerated by running
`make dockerfile-all && make gemfile-all`

Sadly after creating the image using
`make image no-cache=yes DOCKERFILE=v0.12/alpine-elasticsearch VERSION=v0.12-elasticsearch`
and running it locally I have this error
```
docker run --rm fluent/fluentd-kubernetes:v0.12-elasticsearch
/usr/lib/ruby/2.4.0/rubygems.rb:271:in `find_spec_for_exe': can't find gem fluentd (>= 0.a) (Gem::GemNotFoundException)
	from /usr/lib/ruby/2.4.0/rubygems.rb:299:in `activate_bin_path'
	from /usr/bin/fluentd:23:in `<main>'
```

sorry I have no idea about Ruby