### PR TITLE
Use type_name parameter explicitly

### DIFF
--- a/docker-image/v0.12/alpine-elasticsearch/conf/fluent.conf
+++ b/docker-image/v0.12/alpine-elasticsearch/conf/fluent.conf
@@ -18,6 +18,7 @@
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
+   type_name fluentd
    buffer_chunk_limit 2M
    buffer_queue_limit 32
    flush_interval 5s

--- a/docker-image/v0.12/debian-elasticsearch/conf/fluent.conf
+++ b/docker-image/v0.12/debian-elasticsearch/conf/fluent.conf
@@ -19,6 +19,7 @@
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
+   type_name fluentd
    buffer_chunk_limit 2M
    buffer_queue_limit 32
    flush_interval 5s

--- a/docker-image/v1.2/debian-elasticsearch/conf/fluent.conf
+++ b/docker-image/v1.2/debian-elasticsearch/conf/fluent.conf
@@ -19,6 +19,7 @@
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
+   type_name fluentd
    <buffer>
      flush_thread_count 8
      flush_interval 5s

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -25,6 +25,7 @@
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
+   type_name fluentd
 <% if is_v1 %>
    <buffer>
      flush_thread_count 8


### PR DESCRIPTION
Compiatibility with Elasticsearch 6.x.

Multiple mapping types are not supported in Elasticsearch 6.x.  By
default [fluent-plugin-elasticsearch](https://github.com/uken/fluent-plugin-elasticsearch) creates two mapping types per index `[foo,fluentd]`.
See [issue](https://github.com/uken/fluent-plugin-elasticsearch/issues/442)

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>