### PR TITLE
Pass logstash dateformat to elasticsearch plugin

### DIFF
--- a/docker-image/v1.2/debian-elasticsearch/Gemfile.lock
+++ b/docker-image/v1.2/debian-elasticsearch/Gemfile.lock
@@ -27,7 +27,7 @@ GEM
     ffi (1.9.25)
     fluent-config-regexp-type (1.0.0)
       fluentd (> 1.0.0, < 2)
-    fluent-plugin-elasticsearch (2.11.5)
+    fluent-plugin-elasticsearch (2.11.8)
       elasticsearch
       excon
       fluentd (>= 0.14.20)
@@ -113,4 +113,4 @@ DEPENDENCIES
   oj (= 3.5.1)
 
 BUNDLED WITH
-   1.16.1
+   1.16.4

--- a/docker-image/v1.2/debian-elasticsearch/conf/fluent.conf
+++ b/docker-image/v1.2/debian-elasticsearch/conf/fluent.conf
@@ -18,6 +18,7 @@
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
+   logstash_dateformat "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_DATEFORMAT'] || '%Y.%m.%d'}"
    logstash_format true
    type_name fluentd
    <buffer>

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -24,6 +24,7 @@
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
+   logstash_dateformat "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_DATEFORMAT'] || '%Y.%m.%d'}"
    logstash_format true
    type_name fluentd
 <% if is_v1 %>


### PR DESCRIPTION
Currently my cluster is not generating enough daly data to warrant a whole index.
Using a pipeline would probably be a preferable solution but I found this was a quick fix for now.