### PR TITLE
Add ENTRYPOINT to run fluentd as root

### DIFF
--- a/docker-image/v0.12/alpine-cloudwatch/Dockerfile
+++ b/docker-image/v0.12/alpine-cloudwatch/Dockerfile
@@ -45,4 +45,4 @@ ENV FLUENTD_CONF="fluent.conf"
 
 
 # Run Fluentd
-CMD ["/fluentd/entrypoint.sh"]
+ENTRYPOINT ["/fluentd/entrypoint.sh"]


### PR DESCRIPTION
Using [incubator/fluentd-cloudwatch](https://github.com/helm/charts/tree/master/incubator/fluentd-cloudwatch), Had a issue .

This pull request fixes permission issue with fluent user.
Fluent user can't read /var/log, /var/lib. 

This error shows permission error.
``` 
2018-09-12 09:04:06 +0000 [error]: unexpected error error_class=Errno::EACCES error=#<Errno::EACCES: Permission denied @ rb_sysopen - /var/log/fluentd-containers.log.pos>
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/plugin/in_tail.rb:145:in `initialize'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/plugin/in_tail.rb:145:in `open'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/plugin/in_tail.rb:145:in `start'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:115:in `block in start'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:114:in `each'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/root_agent.rb:114:in `start'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/engine.rb:237:in `start'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/engine.rb:187:in `run'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:570:in `run_engine'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:162:in `block in start'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:366:in `main_process'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:339:in `block in supervise'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:338:in `fork'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:338:in `supervise'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/supervisor.rb:156:in `start'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/lib/fluent/command/fluentd.rb:173:in `<top (required)>'
  2018-09-12 09:04:06 +0000 [error]: /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2018-09-12 09:04:06 +0000 [error]: /usr/lib/ruby/2.4.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/gems/fluentd-0.12.43/bin/fluentd:8:in `<top (required)>'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/bin/fluentd:23:in `load'
  2018-09-12 09:04:06 +0000 [error]: /fluentd/vendor/bundle/ruby/2.4.0/bin/fluentd:23:in `<main>'
2018-09-12 09:04:06 +0000 [info]: shutting down fluentd
2018-09-12 09:04:06 +0000 [info]: shutting down filter type="kubernetes_metadata" plugin_id="filter_kube_metadata"
2018-09-12 09:04:06 +0000 [info]: shutting down output type="null" plugin_id="object:2afcf7013d5c"
2018-09-12 09:04:06 +0000 [info]: shutting down output type="cloudwatch_logs" plugin_id="out_cloudwatch_logs"
2018-09-12 09:04:06 +0000 [info]: process finished code=0
2018-09-12 09:04:06 +0000 [warn]: process died within 1 second. exit.
```

When using the CMD command, it run as a fluent user. 
Using the ENTRYPOINT command, it run root user.

Reference: https://github.com/fluent/fluentd-kubernetes-daemonset/pull/119