### PR TITLE
Update papertrail plugin

### DIFF
--- a/docker-image/v1.2/debian-papertrail/Gemfile.lock
+++ b/docker-image/v1.2/debian-papertrail/Gemfile.lock
@@ -23,7 +23,7 @@ GEM
       fluentd (>= 0.14.0, < 2)
       kubeclient (~> 1.1.4)
       lru_redux
-    fluent-plugin-papertrail (0.2.5)
+    fluent-plugin-papertrail (0.2.6)
       fluent-mixin-config-placeholders (~> 0.4.0)
       fluentd (>= 0.10, < 2)
       syslog_protocol


### PR DESCRIPTION
We've encountered some issues with log entries getting truncated before being sent to Papertrail.

The papertrail plugin has since been updated to fix this.

See https://github.com/solarwinds/fluent-plugin-papertrail/issues/17 for more information.