### PR TITLE
Made fluentd buffer params configurable

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -28,20 +28,20 @@
    type_name fluentd
 <% if is_v1 %>
    <buffer>
-     flush_thread_count 8
-     flush_interval 5s
-     chunk_limit_size 2M
-     queue_limit_length 32
-     retry_max_interval 30
+     flush_thread_count "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"
+     flush_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_INTERVAL'] || '5s'}"
+     chunk_limit_size "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_CHUNK_LIMIT_SIZE'] || '2M'}"
+     queue_limit_length "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_QUEUE_LIMIT_LENGTH'] || '32'}"
+     retry_max_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_RETRY_MAX_INTERVAL'] || '30'}"
      retry_forever true
    </buffer>
 <% else %>
-   buffer_chunk_limit 2M
-   buffer_queue_limit 32
-   flush_interval 5s
-   max_retry_wait 30
+   buffer_chunk_limit "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_CHUNK_LIMIT_SIZE'] || '2M'}"
+   buffer_queue_limit "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_QUEUE_LIMIT_LENGTH'] || '32'}"
+   flush_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_INTERVAL'] || '5s'}"
+   max_retry_wait "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_RETRY_MAX_INTERVAL'] || '30'}"
    disable_retry_limit
-   num_threads 8
+   num_threads "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"
 <% end %>
 </match>
 <%  when "logentries"%>


### PR DESCRIPTION
## What
* Allow to config buffer params with env vars

## Why
* Fix `BufferQueueLimitError`

Related:
https://github.com/fluent/fluentd-kubernetes-daemonset/issues/154