### PR TITLE
properly configure v1 buffer for logz.io plugin

### DIFF
--- a/docker-image/v1.1/debian-logzio/conf/fluent.conf
+++ b/docker-image/v1.1/debian-logzio/conf/fluent.conf
@@ -11,26 +11,27 @@
   endpoint_url "https://listener.logz.io:8071?token=#{ENV['LOGZIO_TOKEN']}&type=#{ENV['LOGZIO_LOGTYPE']}"
   output_include_time true
   output_include_tags true
-
-  # Set the buffer type to file to improve the reliability and reduce the memory consumption
-  buffer_type file
-  buffer_path /var/log/fluentd-buffers/stackdriver.buffer
-  # Set queue_full action to block because we want to pause gracefully
-  # in case of the off-the-limits load instead of throwing an exception
-  buffer_queue_full_action block
-  # Set the chunk limit conservatively to avoid exceeding the GCL limit
-  # of 10MiB per write request.
-  buffer_chunk_limit 2M
-  # Cap the combined memory usage of this buffer and the one below to
-  # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-  buffer_queue_limit 6
-  # Never wait more than 5 seconds before flushing logs in the non-error case.
-  flush_interval 5s
-  # Never wait longer than 30 seconds between retries.
-  max_retry_wait 30
-  # Disable the limit on the number of retries (retry forever).
-  # disable_retry_limit
-  # Use multiple threads for processing.
-  num_threads 2
+  <buffer>
+    # Set the buffer type to file to improve the reliability and reduce the memory consumption
+    @type file
+    path /var/log/fluentd-buffers/stackdriver.buffer
+    # Set queue_full action to block because we want to pause gracefully
+    # in case of the off-the-limits load instead of throwing an exception
+    overflow_action block
+    # Set the chunk limit conservatively to avoid exceeding the GCL limit
+    # of 10MiB per write request.
+    chunk_limit_size 2M
+    # Cap the combined memory usage of this buffer and the one below to
+    # 2MiB/chunk * (6 + 2) chunks = 16 MiB
+    queued_chunks_limit_size 6
+    # Never wait more than 5 seconds before flushing logs in the non-error case.
+    flush_interval 5s
+    # Never wait longer than 30 seconds between retries.
+    retry_max_interval 30
+    # Disable the limit on the number of retries (retry forever).
+    retry_forever true
+    # Use multiple threads for processing.
+    flush_thread_count 2
+  </buffer>
 </match>
 

--- a/docker-image/v1.1/debian-logzio/conf/fluent.conf
+++ b/docker-image/v1.1/debian-logzio/conf/fluent.conf
@@ -23,7 +23,7 @@
     chunk_limit_size 2M
     # Cap the combined memory usage of this buffer and the one below to
     # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-    queued_chunks_limit_size 6
+    queue_limit_length 6
     # Never wait more than 5 seconds before flushing logs in the non-error case.
     flush_interval 5s
     # Never wait longer than 30 seconds between retries.

--- a/docker-image/v1.2/debian-logzio/conf/fluent.conf
+++ b/docker-image/v1.2/debian-logzio/conf/fluent.conf
@@ -11,26 +11,27 @@
   endpoint_url "https://listener.logz.io:8071?token=#{ENV['LOGZIO_TOKEN']}&type=#{ENV['LOGZIO_LOGTYPE']}"
   output_include_time true
   output_include_tags true
-
-  # Set the buffer type to file to improve the reliability and reduce the memory consumption
-  buffer_type file
-  buffer_path /var/log/fluentd-buffers/stackdriver.buffer
-  # Set queue_full action to block because we want to pause gracefully
-  # in case of the off-the-limits load instead of throwing an exception
-  buffer_queue_full_action block
-  # Set the chunk limit conservatively to avoid exceeding the GCL limit
-  # of 10MiB per write request.
-  buffer_chunk_limit 2M
-  # Cap the combined memory usage of this buffer and the one below to
-  # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-  buffer_queue_limit 6
-  # Never wait more than 5 seconds before flushing logs in the non-error case.
-  flush_interval 5s
-  # Never wait longer than 30 seconds between retries.
-  max_retry_wait 30
-  # Disable the limit on the number of retries (retry forever).
-  # disable_retry_limit
-  # Use multiple threads for processing.
-  num_threads 2
+  <buffer>
+    # Set the buffer type to file to improve the reliability and reduce the memory consumption
+    @type file
+    path /var/log/fluentd-buffers/stackdriver.buffer
+    # Set queue_full action to block because we want to pause gracefully
+    # in case of the off-the-limits load instead of throwing an exception
+    overflow_action block
+    # Set the chunk limit conservatively to avoid exceeding the GCL limit
+    # of 10MiB per write request.
+    chunk_limit_size 2M
+    # Cap the combined memory usage of this buffer and the one below to
+    # 2MiB/chunk * (6 + 2) chunks = 16 MiB
+    queued_chunks_limit_size 6
+    # Never wait more than 5 seconds before flushing logs in the non-error case.
+    flush_interval 5s
+    # Never wait longer than 30 seconds between retries.
+    retry_max_interval 30
+    # Disable the limit on the number of retries (retry forever).
+    retry_forever true
+    # Use multiple threads for processing.
+    flush_thread_count 2
+  </buffer>
 </match>
 

--- a/docker-image/v1.2/debian-logzio/conf/fluent.conf
+++ b/docker-image/v1.2/debian-logzio/conf/fluent.conf
@@ -23,7 +23,7 @@
     chunk_limit_size 2M
     # Cap the combined memory usage of this buffer and the one below to
     # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-    queued_chunks_limit_size 6
+    queue_limit_length 6
     # Never wait more than 5 seconds before flushing logs in the non-error case.
     flush_interval 5s
     # Never wait longer than 30 seconds between retries.

--- a/docker-image/v1.3/debian-logzio/conf/fluent.conf
+++ b/docker-image/v1.3/debian-logzio/conf/fluent.conf
@@ -11,26 +11,27 @@
   endpoint_url "https://listener.logz.io:8071?token=#{ENV['LOGZIO_TOKEN']}&type=#{ENV['LOGZIO_LOGTYPE']}"
   output_include_time true
   output_include_tags true
-
-  # Set the buffer type to file to improve the reliability and reduce the memory consumption
-  buffer_type file
-  buffer_path /var/log/fluentd-buffers/stackdriver.buffer
-  # Set queue_full action to block because we want to pause gracefully
-  # in case of the off-the-limits load instead of throwing an exception
-  buffer_queue_full_action block
-  # Set the chunk limit conservatively to avoid exceeding the GCL limit
-  # of 10MiB per write request.
-  buffer_chunk_limit 2M
-  # Cap the combined memory usage of this buffer and the one below to
-  # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-  buffer_queue_limit 6
-  # Never wait more than 5 seconds before flushing logs in the non-error case.
-  flush_interval 5s
-  # Never wait longer than 30 seconds between retries.
-  max_retry_wait 30
-  # Disable the limit on the number of retries (retry forever).
-  # disable_retry_limit
-  # Use multiple threads for processing.
-  num_threads 2
+  <buffer>
+    # Set the buffer type to file to improve the reliability and reduce the memory consumption
+    @type file
+    path /var/log/fluentd-buffers/stackdriver.buffer
+    # Set queue_full action to block because we want to pause gracefully
+    # in case of the off-the-limits load instead of throwing an exception
+    overflow_action block
+    # Set the chunk limit conservatively to avoid exceeding the GCL limit
+    # of 10MiB per write request.
+    chunk_limit_size 2M
+    # Cap the combined memory usage of this buffer and the one below to
+    # 2MiB/chunk * (6 + 2) chunks = 16 MiB
+    queued_chunks_limit_size 6
+    # Never wait more than 5 seconds before flushing logs in the non-error case.
+    flush_interval 5s
+    # Never wait longer than 30 seconds between retries.
+    retry_max_interval 30
+    # Disable the limit on the number of retries (retry forever).
+    retry_forever true
+    # Use multiple threads for processing.
+    flush_thread_count 2
+  </buffer>
 </match>
 

--- a/docker-image/v1.3/debian-logzio/conf/fluent.conf
+++ b/docker-image/v1.3/debian-logzio/conf/fluent.conf
@@ -23,7 +23,7 @@
     chunk_limit_size 2M
     # Cap the combined memory usage of this buffer and the one below to
     # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-    queued_chunks_limit_size 6
+    queue_limit_length 6
     # Never wait more than 5 seconds before flushing logs in the non-error case.
     flush_interval 5s
     # Never wait longer than 30 seconds between retries.

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -181,7 +181,7 @@
     chunk_limit_size 2M
     # Cap the combined memory usage of this buffer and the one below to
     # 2MiB/chunk * (6 + 2) chunks = 16 MiB
-    queued_chunks_limit_size 6
+    queue_limit_length 6
     # Never wait more than 5 seconds before flushing logs in the non-error case.
     flush_interval 5s
     # Never wait longer than 30 seconds between retries.

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -168,7 +168,30 @@
   endpoint_url "https://listener.logz.io:8071?token=#{ENV['LOGZIO_TOKEN']}&type=#{ENV['LOGZIO_LOGTYPE']}"
   output_include_time true
   output_include_tags true
-
+<% if is_v1 %>
+  <buffer>
+    # Set the buffer type to file to improve the reliability and reduce the memory consumption
+    @type file
+    path /var/log/fluentd-buffers/stackdriver.buffer
+    # Set queue_full action to block because we want to pause gracefully
+    # in case of the off-the-limits load instead of throwing an exception
+    overflow_action block
+    # Set the chunk limit conservatively to avoid exceeding the GCL limit
+    # of 10MiB per write request.
+    chunk_limit_size 2M
+    # Cap the combined memory usage of this buffer and the one below to
+    # 2MiB/chunk * (6 + 2) chunks = 16 MiB
+    queued_chunks_limit_size 6
+    # Never wait more than 5 seconds before flushing logs in the non-error case.
+    flush_interval 5s
+    # Never wait longer than 30 seconds between retries.
+    retry_max_interval 30
+    # Disable the limit on the number of retries (retry forever).
+    retry_forever true
+    # Use multiple threads for processing.
+    flush_thread_count 2
+  </buffer>
+<% else %>
   # Set the buffer type to file to improve the reliability and reduce the memory consumption
   buffer_type file
   buffer_path /var/log/fluentd-buffers/stackdriver.buffer
@@ -189,6 +212,7 @@
   # disable_retry_limit
   # Use multiple threads for processing.
   num_threads 2
+<% end %>
 </match>
 
 <% when "papertrail"%>


### PR DESCRIPTION
currently running the fluentd logz.io container spits out warnings on start for an improperly configured buffer plugin on the v1.* images.

```
2018-11-27 18:32:11 +0000 [warn]: parameter '@type' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
2018-11-27 18:32:11 +0000 [warn]: parameter 'path' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
2018-11-27 18:32:11 +0000 [warn]: parameter 'flush_thread_count' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
2018-11-27 18:32:11 +0000 [warn]: parameter 'flush_interval' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
2018-11-27 18:32:11 +0000 [warn]: parameter 'retry_max_interval' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
2018-11-27 18:32:11 +0000 [warn]: parameter 'chunk_limit_size' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
2018-11-27 18:32:11 +0000 [warn]: parameter 'queue_limit_length' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
2018-11-27 18:32:11 +0000 [warn]: parameter 'overflow_action' in <buffer>
  @type file
  path /var/log/fluentd-buffers/stackdriver.buffer
  flush_thread_count 2
  flush_interval 5s
  retry_max_interval 30
  chunk_limit_size 2M
  queue_limit_length 6
  overflow_action block
</buffer> is not used.
```