### PR TITLE
Include external configuration files

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -9,6 +9,7 @@
 @include systemd.conf
 <% end%>
 @include kubernetes.conf
+@include conf.d/*.conf
 
 <% case target when "elasticsearch"%>
 <match **>


### PR DESCRIPTION
In order to allow customizing some configuration without having to rebuild the image, we include all the configuration files in `/fluentd/etc/conf.d`

Partially solves #174
Provides a way to solve #181