### PR TITLE
Regenerate templates for fluentd

### DIFF
--- a/docker-image/v0.12/debian-elasticsearch/conf/fluent.conf
+++ b/docker-image/v0.12/debian-elasticsearch/conf/fluent.conf
@@ -20,10 +20,10 @@
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
    type_name fluentd
-   buffer_chunk_limit 2M
-   buffer_queue_limit 32
-   flush_interval 5s
-   max_retry_wait 30
+   buffer_chunk_limit "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_CHUNK_LIMIT_SIZE'] || '2M'}"
+   buffer_queue_limit "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_QUEUE_LIMIT_LENGTH'] || '32'}"
+   flush_interval "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_INTERVAL'] || '5s'}"
+   max_retry_wait "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_RETRY_MAX_INTERVAL'] || '30'}"
    disable_retry_limit
-   num_threads 8
+   num_threads "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"
 </match>


### PR DESCRIPTION
## What
* Regenerate `fluentd.conf` from template for `v0.12-debian-elasticsearch`

## Why
* To support https://github.com/fluent/fluentd-kubernetes-daemonset/pull/202