### PR TITLE
Log rejected requests if `log_rejected_request` is true

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -33,7 +33,7 @@ gem "fluent-plugin-loggly"
 <% when "cloudwatch" %>
 gem "aws-sdk-cloudwatchlogs", "~> 1.0"
 <% if is_v1 %>
-gem "fluent-plugin-cloudwatch-logs", "~> 0.6.1"
+gem "fluent-plugin-cloudwatch-logs", "~> 0.7.2"
 <% else %>
 gem "fluent-plugin-cloudwatch-logs", "0.4.5"
 <% end %>

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -71,6 +71,7 @@
   use_tag_as_stream true
 <% if is_v1 %>
   json_handler yajl # To avoid UndefinedConversionError
+  log_rejected_request "#{ENV['LOG_REJECTED_REQUEST']}" # Log rejected request for missing parts
 <% end %>
 </match>
 <%  when "s3"%>


### PR DESCRIPTION
This feature is requested in https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/issues/135.