### PR TITLE
debian-elasticsearch: expose option to reconnect to ES on error

### DIFF
--- a/docker-image/v1.3/debian-elasticsearch/conf/fluent.conf
+++ b/docker-image/v1.3/debian-elasticsearch/conf/fluent.conf
@@ -19,6 +19,7 @@
    user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
+   reconnect_on_error "#{ENV['FLUENT_ELASTICSEARCH_RECONNECT_ON_ERROR'] || 'false'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
    type_name fluentd

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -25,6 +25,7 @@
    user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
+   reconnect_on_error "#{ENV['FLUENT_ELASTICSEARCH_RECONNECT_ON_ERROR'] || 'false'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format true
    type_name fluentd


### PR DESCRIPTION
Fixes #257 

The elasticsearch fluentd plugin recommends enabling the
["reconnect_on_error" option](https://github.com/uken/fluent-plugin-elasticsearch#reconnect_on_error) when shipping logs to an ElasticSearch
cluster that has ElasticSearch Shield enabled.

Expose an environment variable that can be set in the daemonset to
control the value of the "reconnect_on_error" option.

Signed-off-by: Alexander Brand <alexbrand09@gmail.com>