### PR TITLE
Add fluent-plugin-grok-parser plugin to base. fix #214

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -11,6 +11,7 @@ gem "fluentd", "<%= fluentd_ver %>"
 gem "oj", "3.5.1"
 gem "fluent-plugin-multi-format-parser", "~> 1.0.0"
 gem "fluent-plugin-concat", "~> 2.3.0"
+gem "fluent-plugin-grok-parser", "~> 2.5.0"
 <% if !is_v1 %>
 gem "fluent-plugin-secure-forward"
 gem "fluent-plugin-record-reformer"


### PR DESCRIPTION
grok parser is widely used so add it to base seems useful for users.

Signed-off-by: Masahiro Nakagawa <repeatedly@gmail.com>