### PR TITLE
Add FLUENT_ELASTICSEARCH_RELOAD_ON_FAILURE envvar to suppress unstable sniffering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 
 IMAGE_NAME := fluent/fluentd-kubernetes
 ALL_IMAGES := \
-	v1.3/debian-elasticsearch:v1.3.3-debian-elasticsearch-1.4,v1.3-debian-elasticsearch-1 \
+	v1.3/debian-elasticsearch:v1.3.3-debian-elasticsearch-1.5,v1.3-debian-elasticsearch-1 \
 	v1.3/debian-loggly:v1.3.3-debian-loggly-1.2,v1.3-debian-loggly-1 \
 	v1.3/debian-logentries:v1.3.3-debian-logentries-1.2,v1.3-debian-logentries-1 \
 	v1.3/debian-cloudwatch:v1.3.3-debian-cloudwatch-1.3,v1.3-debian-cloudwatch-1 \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 
 ### Debian
 
-- `v1.3.3-debian-elasticsearch-1.4,v1.3-debian-elasticsearch-1` [docker-image/v1.3/debian-elasticsearch/Dockerfile](docker-image/v1.3/debian-elasticsearch/Dockerfile)
+- `v1.3.3-debian-elasticsearch-1.5,v1.3-debian-elasticsearch-1` [docker-image/v1.3/debian-elasticsearch/Dockerfile](docker-image/v1.3/debian-elasticsearch/Dockerfile)
 - `v1.3.3-debian-loggly-1.2,v1.3-debian-loggly-1` [docker-image/v1.3/debian-loggly/Dockerfile](docker-image/v1.3/debian-loggly/Dockerfile)
 - `v1.3.3-debian-logentries-1.2,v1.3-debian-logentries-1` [docker-image/v1.3/debian-logentries/Dockerfile](docker-image/v1.3/debian-logentries/Dockerfile)
 - `v1.3.3-debian-cloudwatch-1.3,v1.3-debian-cloudwatch-1` [docker-image/v1.3/debian-cloudwatch/Dockerfile](docker-image/v1.3/debian-cloudwatch/Dockerfile)

--- a/docker-image/v1.3/debian-elasticsearch/conf/fluent.conf
+++ b/docker-image/v1.3/debian-elasticsearch/conf/fluent.conf
@@ -21,6 +21,7 @@
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    reconnect_on_error "#{ENV['FLUENT_ELASTICSEARCH_RECONNECT_ON_ERROR'] || 'false'}"
+   reload_on_failure "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_ON_FAILURE'] || 'false'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT'] || 'true'}"
    index_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME'] || 'logstash'}"

--- a/docker-image/v1.3/debian-elasticsearch/hooks/post_push
+++ b/docker-image/v1.3/debian-elasticsearch/hooks/post_push
@@ -9,7 +9,7 @@ tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
 # Tag and push image for each additional tag
-for tag in {v1.3.3-debian-elasticsearch-1.4,v1.3-debian-elasticsearch-1}; do
+for tag in {v1.3.3-debian-elasticsearch-1.5,v1.3-debian-elasticsearch-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
 done

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -25,6 +25,7 @@
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'true'}"
    reconnect_on_error "#{ENV['FLUENT_ELASTICSEARCH_RECONNECT_ON_ERROR'] || 'false'}"
+   reload_on_failure "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_ON_FAILURE'] || 'false'}"
    logstash_prefix "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
    logstash_format "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT'] || 'true'}"
    index_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME'] || 'logstash'}"


### PR DESCRIPTION
This is reported in
https://github.com/uken/fluent-plugin-elasticsearch/issues/525.

Invalid sniffer information is obtained by default, but we can avoid
the following configuration:

```aconf
reload_connections false
reconnect_on_error true
reload_on_failure true
```

To specify reload_on_failure on fluentd-kubernetes-daemonset,
we should introduce a new envver to specify it.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>