### PR TITLE
Expose retention policy for CloudWatch.

### DIFF
--- a/docker-image/v1.3/debian-cloudwatch/conf/fluent.conf
+++ b/docker-image/v1.3/debian-cloudwatch/conf/fluent.conf
@@ -12,7 +12,7 @@
   log_group_name "#{ENV['LOG_GROUP_NAME']}"
   auto_create_stream true
   use_tag_as_stream true
-  retention_in_days "#{ENV['RETENTION_IN_DAYS']}"
+  retention_in_days "#{ENV['RETENTION_IN_DAYS'] || 'nil'}"
   json_handler yajl # To avoid UndefinedConversionError
   log_rejected_request "#{ENV['LOG_REJECTED_REQUEST']}" # Log rejected request for missing parts
 </match>

--- a/docker-image/v1.3/debian-cloudwatch/conf/fluent.conf
+++ b/docker-image/v1.3/debian-cloudwatch/conf/fluent.conf
@@ -12,6 +12,7 @@
   log_group_name "#{ENV['LOG_GROUP_NAME']}"
   auto_create_stream true
   use_tag_as_stream true
+  retention_in_days "#{ENV['RETENTION_IN_DAYS']}"
   json_handler yajl # To avoid UndefinedConversionError
   log_rejected_request "#{ENV['LOG_REJECTED_REQUEST']}" # Log rejected request for missing parts
 </match>

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -71,6 +71,7 @@
   log_group_name "#{ENV['LOG_GROUP_NAME']}"
   auto_create_stream true
   use_tag_as_stream true
+  retention_in_days "#{ENV['RETENTION_IN_DAYS']}"
 <% if is_v1 %>
   json_handler yajl # To avoid UndefinedConversionError
   log_rejected_request "#{ENV['LOG_REJECTED_REQUEST']}" # Log rejected request for missing parts

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -71,7 +71,7 @@
   log_group_name "#{ENV['LOG_GROUP_NAME']}"
   auto_create_stream true
   use_tag_as_stream true
-  retention_in_days "#{ENV['RETENTION_IN_DAYS']}"
+  retention_in_days "#{ENV['RETENTION_IN_DAYS'] || 'nil'}"
 <% if is_v1 %>
   json_handler yajl # To avoid UndefinedConversionError
   log_rejected_request "#{ENV['LOG_REJECTED_REQUEST']}" # Log rejected request for missing parts


### PR DESCRIPTION
Exposes the retention policy for CloudWatch (`retention_in_days`) via an environment variable (`RETENTION_IN_DAYS`) so it can be configured when deploying the daemonset.