### PR TITLE
Make logentries configurable to send logs to InsightOps

### DIFF
--- a/docker-image/v0.12/alpine-logentries/plugins/out_logentries.rb
+++ b/docker-image/v0.12/alpine-logentries/plugins/out_logentries.rb
@@ -20,9 +20,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -42,16 +41,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/docker-image/v1.1/debian-logentries/plugins/out_logentries.rb
+++ b/docker-image/v1.1/debian-logentries/plugins/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/docker-image/v1.2/debian-logentries/plugins/out_logentries.rb
+++ b/docker-image/v1.2/debian-logentries/plugins/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/docker-image/v1.3/debian-logentries/conf/fluent.conf
+++ b/docker-image/v1.3/debian-logentries/conf/fluent.conf
@@ -10,8 +10,15 @@
 <match **>
    @type logentries
    @id out_logentries
-   use_json true
-   tag_access_log stdout
-   tag_error_log stderr
-   config_path /etc/logentries/tokens.yaml
+   use_ssl "#{ENV['FLUENT_LOGENTRIES_USE_SSL'] || nil}"
+   use_json "#{ENV['FLUENT_LOGENTRIES_USE_JSON'] || nil}"
+   port "#{ENV['FLUENT_LOGENTRIES_PORT'] || nil}"
+   protocol "#{ENV['FLUENT_LOGENTRIES_PROTOCOL'] || nil}"
+   config_path "#{ENV['FLUENT_LOGENTRIES_CONFIG_PATH'] || '/etc/logentries/tokens.yaml'}"
+   max_retries "#{ENV['FLUENT_LOGENTRIES_MAX_RETRIES'] || nil}"
+   tag_access_log "#{ENV['FLUENT_LOGENTRIES_TAG_ACCESS_LOG'] || nil}"
+   tag_error_log "#{ENV['FLUENT_LOGENTRIES_TAG_ERROR_LOG'] || nil}"
+   default_token "#{ENV['FLUENT_LOGENTRIES_DEFAULT_TOKEN'] || nil}"
+   ssl_host "#{ENV['FLUENT_LOGENTRIES_SSL_HOST'] || nil}"
+   no_ssl_host "#{ENV['FLUENT_LOGENTRIES_NO_SSL_HOST'] || nil}"
 </match>

--- a/docker-image/v1.3/debian-logentries/plugins/out_logentries.rb
+++ b/docker-image/v1.3/debian-logentries/plugins/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/docker-image/v1.4/debian-logentries/conf/fluent.conf
+++ b/docker-image/v1.4/debian-logentries/conf/fluent.conf
@@ -10,8 +10,15 @@
 <match **>
    @type logentries
    @id out_logentries
-   use_json true
-   tag_access_log stdout
-   tag_error_log stderr
-   config_path /etc/logentries/tokens.yaml
+   use_ssl "#{ENV['FLUENT_LOGENTRIES_USE_SSL'] || nil}"
+   use_json "#{ENV['FLUENT_LOGENTRIES_USE_JSON'] || nil}"
+   port "#{ENV['FLUENT_LOGENTRIES_PORT'] || nil}"
+   protocol "#{ENV['FLUENT_LOGENTRIES_PROTOCOL'] || nil}"
+   config_path "#{ENV['FLUENT_LOGENTRIES_CONFIG_PATH'] || '/etc/logentries/tokens.yaml'}"
+   max_retries "#{ENV['FLUENT_LOGENTRIES_MAX_RETRIES'] || nil}"
+   tag_access_log "#{ENV['FLUENT_LOGENTRIES_TAG_ACCESS_LOG'] || nil}"
+   tag_error_log "#{ENV['FLUENT_LOGENTRIES_TAG_ERROR_LOG'] || nil}"
+   default_token "#{ENV['FLUENT_LOGENTRIES_DEFAULT_TOKEN'] || nil}"
+   ssl_host "#{ENV['FLUENT_LOGENTRIES_SSL_HOST'] || nil}"
+   no_ssl_host "#{ENV['FLUENT_LOGENTRIES_NO_SSL_HOST'] || nil}"
 </match>

--- a/docker-image/v1.4/debian-logentries/plugins/out_logentries.rb
+++ b/docker-image/v1.4/debian-logentries/plugins/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/fluentd-daemonset-logentries.yaml
+++ b/fluentd-daemonset-logentries.yaml
@@ -46,6 +46,33 @@ spec:
         - name: varlibdockercontainers
           mountPath: /var/lib/docker/containers
           readOnly: true
+        env:
+        - name: FLUENTD_SYSTEMD_CONF
+          value: "disable"
+        #- name: FLUENT_LOGENTRIES_TAG_ACCESS_LOG
+        #  value: "stdout"
+        #- name: FLUENT_LOGENTRIES_TAG_ERROR_LOG
+        #  value: "stderr"
+        #- name: FLUENT_LOGENTRIES_USE_SSL
+        #  value: "true"
+        - name: FLUENT_LOGENTRIES_USE_JSON
+          value: "true"
+        - name: FLUENT_LOGENTRIES_PORT
+          value: "443"
+        #- name: FLUENT_LOGENTRIES_PROTOCOL
+        #  value: "tcp"
+        #- name: FLUENT_LOGENTRIES_CONFIG_PATH
+        #  value: "/etc/logentries/tokens.yaml"
+        #- name: FLUENT_LOGENTRIES_MAX_RETRIES
+        #  value: "3"
+        #- name: FLUENT_LOGENTRIES_TAG_ACCESS_LOG
+        #  value: "logs-access"
+        #- name: FLUENT_LOGENTRIES_TAG_ERROR_LOG
+        #  value: "logs-error"
+        #- name: FLUENT_LOGENTRIES_NO_SSL_HOST
+        #  value: "REGION.data.logs.insight.rapid7.com"
+        #- name: FLUENT_LOGENTRIES_SSL_HOST
+        #  value: "REGION.data.logs.insight.rapid7.com"
       terminationGracePeriodSeconds: 30
       volumes:
       - name: logentries-config

--- a/plugins/v0.12/logentries/out_logentries.rb
+++ b/plugins/v0.12/logentries/out_logentries.rb
@@ -20,9 +20,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -42,16 +41,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/plugins/v1.1/logentries/out_logentries.rb
+++ b/plugins/v1.1/logentries/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/plugins/v1.2/logentries/out_logentries.rb
+++ b/plugins/v1.2/logentries/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/plugins/v1.3/logentries/out_logentries.rb
+++ b/plugins/v1.3/logentries/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/plugins/v1.4/logentries/out_logentries.rb
+++ b/plugins/v1.4/logentries/out_logentries.rb
@@ -21,9 +21,8 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   config_param :tag_access_log, :string,  :default => 'logs-access'
   config_param :tag_error_log,  :string,  :default => 'logs-error'
   config_param :default_token,  :string,  :default => nil
-
-  SSL_HOST    = "api.logentries.com"
-  NO_SSL_HOST = "data.logentries.com"
+  config_param :ssl_host,       :string,  :default => 'api.logentries.com'
+  config_param :no_ssl_host,    :string,  :default => 'data.logentries.com'
 
   def configure(conf)
     super
@@ -43,16 +42,16 @@ class Fluent::LogentriesOutput < Fluent::BufferedOutput
   def client
     @_socket ||= if @use_ssl
       context    = OpenSSL::SSL::SSLContext.new
-      socket     = TCPSocket.new SSL_HOST, @port
+      socket     = TCPSocket.new @ssl_host, @port
       ssl_client = OpenSSL::SSL::SSLSocket.new socket, context
 
       ssl_client.connect
     else
       if @protocol == 'tcp'
-        TCPSocket.new NO_SSL_HOST, @port
+        TCPSocket.new @no_ssl_host, @port
       else
         udp_client = UDPSocket.new
-        udp_client.connect NO_SSL_HOST, @port
+        udp_client.connect @no_ssl_host, @port
 
         udp_client
       end

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -53,10 +53,17 @@
 <match **>
    @type logentries
    @id out_logentries
-   use_json true
-   tag_access_log stdout
-   tag_error_log stderr
-   config_path /etc/logentries/tokens.yaml
+   use_ssl "#{ENV['FLUENT_LOGENTRIES_USE_SSL'] || nil}"
+   use_json "#{ENV['FLUENT_LOGENTRIES_USE_JSON'] || nil}"
+   port "#{ENV['FLUENT_LOGENTRIES_PORT'] || nil}"
+   protocol "#{ENV['FLUENT_LOGENTRIES_PROTOCOL'] || nil}"
+   config_path "#{ENV['FLUENT_LOGENTRIES_CONFIG_PATH'] || '/etc/logentries/tokens.yaml'}"
+   max_retries "#{ENV['FLUENT_LOGENTRIES_MAX_RETRIES'] || nil}"
+   tag_access_log "#{ENV['FLUENT_LOGENTRIES_TAG_ACCESS_LOG'] || nil}"
+   tag_error_log "#{ENV['FLUENT_LOGENTRIES_TAG_ERROR_LOG'] || nil}"
+   default_token "#{ENV['FLUENT_LOGENTRIES_DEFAULT_TOKEN'] || nil}"
+   ssl_host "#{ENV['FLUENT_LOGENTRIES_SSL_HOST'] || nil}"
+   no_ssl_host "#{ENV['FLUENT_LOGENTRIES_NO_SSL_HOST'] || nil}"
 </match>
 <%  when "loggly"%>
 <match **>


### PR DESCRIPTION
After Logentries became InsightOps, the endpoints (`ssl_host` or `no_ssl_host`) has changed and become dynamic. The region (e.g. `eu`, `us`, `ap`, etc.) is part of the endpoint. [See docs](https://insightops.help.rapid7.com/docs/token-tcp#section-endpoints).

This pull requests keeps the defaults the same, but allows the host and other options for Logentries to be configurable.