### PR TITLE
Add RBAC support to Logentries (aka: InsightOps)

### DIFF
--- a/fluentd-daemonset-logentries.yaml
+++ b/fluentd-daemonset-logentries.yaml
@@ -1,5 +1,43 @@
 ---
 apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: fluentd
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: fluentd
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: fluentd
+roleRef:
+  kind: ClusterRole
+  name: fluentd
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: fluentd
+  namespace: kube-system
+
+---
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: fluentd-logentries
@@ -26,6 +64,7 @@ spec:
         k8s-app: fluentd
         kubernetes.io/cluster-service: "true"
     spec:
+      serviceAccountName: fluentd
       tolerations:
       - key: node-role.kubernetes.io/master
         effect: NoSchedule


### PR DESCRIPTION
This PR provides an RBAC policy for LogEntries (aka: InsightOps). It fixes this error that the fluentd pod produces when there is no RBAC policy:
```
2019-05-07 08:35:57 +0000 [error]: config error file="/fluentd/etc/fluent.conf" error_class=Fluent::ConfigError error="Exception encountered fetching metadata from Kubernetes API endpoint: pods is forbidden: User \"system:serviceaccount:kube-system:default\" cannot list resource \"pods\" in API group \"\" at the cluster scope ({\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"pods is forbidden: User \\\"system:serviceaccount:kube-system:default\\\" cannot list resource \\\"pods\\\" in API group \\\"\\\" at the cluster scope\",\"reason\":\"Forbidden\",\"details\":{\"kind\":\"pods\"},\"code\":403}\n)"
```