### PR TITLE
Use Secret for Logentries

### DIFF
--- a/fluentd-daemonset-logentries.yaml
+++ b/fluentd-daemonset-logentries.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
   name: fluentd-logentries
   namespace: kube-system
@@ -49,8 +49,8 @@ spec:
       terminationGracePeriodSeconds: 30
       volumes:
       - name: logentries-config
-        configMap:
-          name: fluentd-logentries
+        secret:
+          secretName: fluentd-logentries
       - name: varlog
         hostPath:
           path: /var/log


### PR DESCRIPTION
Since the data contains a token, `Secret` should be used instead of `ConfigMap`.

Signed-off-by: Frank Lee <frank@cryptact.com>