### PR TITLE
Update fluentd-daemonset-cloudwatch-rbac.yaml to use latest image

### DIFF
--- a/fluentd-daemonset-cloudwatch-rbac.yaml
+++ b/fluentd-daemonset-cloudwatch-rbac.yaml
@@ -62,7 +62,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: fluentd
-        image: fluent/fluentd-kubernetes-daemonset:cloudwatch
+        image: fluent/fluentd-kubernetes-daemonset:v1.4-debian-cloudwatch-1
         env:
           - name: LOG_GROUP_NAME
             value: "k8s"


### PR DESCRIPTION
The image `fluent/fluentd-kubernetes-daemonset:cloudwatch` referred in the example seems to be old and not maintained, so changed it to latest one.