### PR TITLE
Update to allow different chunk_limit_size for kinesis

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -361,7 +361,7 @@
 <% if is_v1 %>
   <buffer>
     flush_interval 1
-    chunk_limit_size "#{ENV['FLUENT_KINESIS_STREAMS_CHUNK_LIMIT_SIZE'] || 1m}"
+    chunk_limit_size "#{ENV['FLUENT_KINESIS_STREAMS_CHUNK_LIMIT_SIZE'] || '1m'}"
     flush_thread_interval 0.1
     flush_thread_burst_interval 0.01
     flush_thread_count 15

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -361,7 +361,7 @@
 <% if is_v1 %>
   <buffer>
     flush_interval 1
-    chunk_limit_size 1m
+    chunk_limit_size "#{ENV['FLUENT_KINESIS_STREAMS_CHUNK_LIMIT_SIZE'] || 1m}"
     flush_thread_interval 0.1
     flush_thread_burst_interval 0.01
     flush_thread_count 15


### PR DESCRIPTION
This issue details why this PR was made.  https://github.com/fluent/fluentd-kubernetes-daemonset/issues/325

Allows the user to set different chunk_limit_size based on env var