### PR TITLE
remove obsolete flag from the metadata

### DIFF
--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -6,14 +6,12 @@ metadata:
   labels:
     k8s-app: fluentd-logging
     version: v1
-    kubernetes.io/cluster-service: "true"
 spec:
   template:
     metadata:
       labels:
         k8s-app: fluentd-logging
         version: v1
-        kubernetes.io/cluster-service: "true"
     spec:
       tolerations:
       - key: node-role.kubernetes.io/master


### PR DESCRIPTION
This flag was deprecated long time ago:
https://github.com/kubernetes/kubernetes/issues/51376

and is now causing issues to the DaemonSet, that's also backfiring to
the fluentd containers.

Tried installing the `fluentd-elasticsearch` via Helm and the containers were failing to initialize because of this deprecated flag that was present in the DaemonSet. Tested this on a Kubernetes cluster v1.14.4 on AWS.

This flag can still be found in the DaemonSet of [`fluentd-elasticsearch` Helm Chart](https://github.com/kiwigrid/helm-charts/blob/master/charts/fluentd-elasticsearch/templates/daemonset.yaml#L10)

If this flag is present in the DaemonSet, the `fluentd` container will blow up with the following exception:

```sh
2019-07-23 17:29:29 +0000 [error]: unexpected error error_class=NoMethodError error="undefined method `[]' for nil:NilClass"
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/out_elasticsearch.rb:335:in `detect_es_major_version'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/out_elasticsearch.rb:245:in `block in configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/elasticsearch_index_template.rb:35:in `retry_operate'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluent-plugin-elasticsearch-3.5.2/lib/fluent/plugin/out_elasticsearch.rb:244:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/plugin.rb:164:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:130:in `add_match'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:72:in `block in configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:64:in `each'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/agent.rb:64:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/root_agent.rb:150:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/engine.rb:131:in `configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/engine.rb:96:in `run_configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:801:in `run_configure'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:548:in `block in run_worker'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:730:in `main_process'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/supervisor.rb:544:in `run_worker'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/lib/fluent/command/fluentd.rb:316:in `<top (required)>'
  2019-07-23 17:29:29 +0000 [error]: /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2019-07-23 17:29:29 +0000 [error]: /usr/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
  2019-07-23 17:29:29 +0000 [error]: /var/lib/gems/2.3.0/gems/fluentd-1.5.1/bin/fluentd:8:in `<top (required)>'
  2019-07-23 17:29:29 +0000 [error]: /usr/local/bin/fluentd:22:in `load'
  2019-07-23 17:29:29 +0000 [error]: /usr/local/bin/fluentd:22:in `<main>'
```

Resolves:
Related: kubernetes/kubernetes#51376