### PR TITLE
Made the protocol available to the graylog config

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -167,6 +167,7 @@
   include_tag_key true
   host "#{ENV['FLUENT_GRAYLOG_HOST']}"
   port "#{ENV['FLUENT_GRAYLOG_PORT']}"
+  protocol "#{ENV['FLUENT_GRAYLOG_PROTOCOL'] || 'udp'}"
   <buffer>
     flush_thread_count 8
     flush_interval 5s


### PR DESCRIPTION
# Changelog
- Made the ENV "FLUENT_GRAYLOG_PROTOCOL" which fixes issue https://github.com/fluent/fluentd-kubernetes-daemonset/issues/283

This is useful specifically because with Graylog you need to specify using TCP/UDP so using the default UDP protocol is very limiting 