### PR TITLE
adding fluent-plugin-detect-exceptions plugin to fluentd-elasticsearch docker image

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -25,9 +25,11 @@ gem "fluent-plugin-rewrite-tag-filter", "~> 2.2.0"
 <% case target when "elasticsearch6" %>
 gem "elasticsearch", "~> 6.0"
 gem "fluent-plugin-elasticsearch", "~> 3.5.5"
+gem "fluent-plugin-detect-exceptions", "~> 0.0.12"
 <% when "elasticsearch7" %>
 gem "elasticsearch", "~> 7.0"
 gem "fluent-plugin-elasticsearch", "~> 3.5.5"
+gem "fluent-plugin-detect-exceptions", "~> 0.0.12"
 <% when "logentries" %>
 #gem "fluent-plugin-logentries"
 <% when "loggly"%>


### PR DESCRIPTION
Adding fluent-plugin-detect-exceptions plugin to fluentd docker image for elasticsearch.

This plugin help for multi language exception/stack-trace logging.

We get exceptions/stack-trace as combined lines not line by line which is not useful in Kibana.