### PR TITLE
Changed TLS version

### DIFF
--- a/docker-image/v1.7/debian-elasticsearch7/conf/fluent.conf
+++ b/docker-image/v1.7/debian-elasticsearch7/conf/fluent.conf
@@ -17,7 +17,7 @@
    path "#{ENV['FLUENT_ELASTICSEARCH_PATH']}"
    scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
    ssl_verify "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERIFY'] || 'true'}"
-   ssl_version "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERSION'] || 'TLSv1'}"
+   ssl_version "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERSION'] || 'TLSv1_2'}"
    user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'false'}"


### PR DESCRIPTION
I could be wrong but I think elasticsearch7.0 and up only accepts TLS1.1 or more because i just had issues with that, so is there any reason to leave the default as TLS1 here?