### PR TITLE
add fluent-plugin-detect-exceptions to all images

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -15,6 +15,7 @@ gem "fluent-plugin-grok-parser", "~> 2.5.0"
 gem "fluent-plugin-prometheus", "~> 1.5.0"
 gem 'fluent-plugin-json-in-json-2', ">= 1.0.2"
 gem "fluent-plugin-record-modifier", "~> 2.0.0"
+gem "fluent-plugin-detect-exceptions", "~> 0.0.12"
 <% if !is_v1 %>
 gem "fluent-plugin-secure-forward"
 gem "fluent-plugin-record-reformer"
@@ -25,11 +26,9 @@ gem "fluent-plugin-rewrite-tag-filter", "~> 2.2.0"
 <% case target when "elasticsearch6" %>
 gem "elasticsearch", "~> 6.0"
 gem "fluent-plugin-elasticsearch", "~> 3.5.5"
-gem "fluent-plugin-detect-exceptions", "~> 0.0.12"
 <% when "elasticsearch7" %>
 gem "elasticsearch", "~> 7.0"
 gem "fluent-plugin-elasticsearch", "~> 3.5.5"
-gem "fluent-plugin-detect-exceptions", "~> 0.0.12"
 <% when "logentries" %>
 #gem "fluent-plugin-logentries"
 <% when "loggly"%>


### PR DESCRIPTION
PR #349 added fluent-plugin-detect-exceptions to the elasticsearch images. This PR adds it across all images as it is generally quite useful.
