### PR TITLE
Added possibility for custom tail tag via environment variable

### DIFF
--- a/docker-image/v1.7/debian-cloudwatch/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-cloudwatch/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-elasticsearch/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-elasticsearch/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-elasticsearch6/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-elasticsearch6/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-elasticsearch7/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-elasticsearch7/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-forward/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-forward/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-gcs/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-gcs/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-graylog/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-graylog/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-kafka/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-kafka/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-kinesis/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-kinesis/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-logentries/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-logentries/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-loggly/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-loggly/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-logzio/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-logzio/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-papertrail/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-papertrail/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-s3/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-s3/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-stackdriver/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-stackdriver/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"

--- a/docker-image/v1.7/debian-syslog/conf/kubernetes.conf
+++ b/docker-image/v1.7/debian-syslog/conf/kubernetes.conf
@@ -10,7 +10,7 @@
   @id in_tail_container_logs
   path /var/log/containers/*.log
   pos_file /var/log/fluentd-containers.log.pos
-  tag kubernetes.*
+  tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   read_from_head true
   <parse>
     @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"


### PR DESCRIPTION
Added possibility for custom tail tag via environment variable, which is useful for detect_exception plugin which removes a tag prefix. Then having only kubernetes.* simply isn't enough for later manipulation or using rewrite_tag plugin. The change is done in a way that is backwards compatible, so it defaults to "kubernetes.*".

Example of having set a custom prefix like "raw.kubernetes.*" and how it benefits in a rewrite tag filter, because detect_exceptions removes a prefix.

    <match raw.kubernetes.**>
      @id raw.kubernetes
      @type detect_exceptions
      remove_tag_prefix raw
      message log
      languages all
      stream stream
      multiline_flush_interval 5
      max_bytes 500000
      max_lines 1000
    </match>

    <match kubernetes.**>
      @type rewrite_tag_filter
      <rule>
        key $.kubernetes.namespace_name
        pattern ^(.+)$
        tag $1
      </rule>
    </match>

Signed-off-by: Willi Carlsen <carlsenwilli@gmail.com>