### PR TITLE
Add options for TLS version and verify explicitly

### DIFF
--- a/fluentd-daemonset-elasticsearch-rbac.yaml
+++ b/fluentd-daemonset-elasticsearch-rbac.yaml
@@ -70,6 +70,14 @@ spec:
             value: "9200"
           - name: FLUENT_ELASTICSEARCH_SCHEME
             value: "http"
+          # Option to configure elasticsearch plugin with self signed certs
+          # ================================================================
+          - name: FLUENT_ELASTICSEARCH_SSL_VERIFY
+            value: "true"
+          # Option to configure elasticsearch plugin with tls
+          # ================================================================
+          - name: FLUENT_ELASTICSEARCH_SSL_VERSION
+            value: "TLSv1_2"
           # X-Pack Authentication
           # =====================
           - name: FLUENT_ELASTICSEARCH_USER

--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -30,6 +30,10 @@ spec:
           # ================================================================
           - name: FLUENT_ELASTICSEARCH_SSL_VERIFY
             value: "true"
+          # Option to configure elasticsearch plugin with tls
+          # ================================================================
+          - name: FLUENT_ELASTICSEARCH_SSL_VERSION
+            value: "TLSv1_2"
           # X-Pack Authentication
           # =====================
           - name: FLUENT_ELASTICSEARCH_USER


### PR DESCRIPTION
Because recent Elasticsearch clusters usually use TLSv1.2,
however, fluent-plugin-elasticsearch's default value of SSL/TLS version
is TLSv1.

ref: https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v1.7/debian-elasticsearch7/conf/fluent.conf#L20

Related to https://github.com/fluent/fluentd-kubernetes-daemonset/issues/363.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>