### PR TITLE
update elasticsearch plugin for elasticsearch 7

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -28,7 +28,8 @@ gem "elasticsearch", "~> 6.0"
 gem "fluent-plugin-elasticsearch", "~> 3.5.5"
 <% when "elasticsearch7" %>
 gem "elasticsearch", "~> 7.0"
-gem "fluent-plugin-elasticsearch", "~> 3.5.5"
+gem "fluent-plugin-elasticsearch", "~> 3.7.1"
+gem "elasticsearch-xpack", "~> 7.4.0"
 <% when "logentries" %>
 #gem "fluent-plugin-logentries"
 <% when "loggly"%>


### PR DESCRIPTION
This PR will update the elasticsearch plugin to the 3.7.1 version and add the elasticsearch-xpack gem to be able to use ILM from within the plugin.