### PR TITLE
Adding SASL_SSL dependencies for the rdkafka plugin

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -18,12 +18,13 @@ ENV FLUENTD_DISABLE_BUNDLER_INJECTION 1
 
 COPY Gemfile* /fluentd/
   RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev<% if target == "graylog" %> build-essential patch zlib1g-dev liblzma-dev<% elsif target == "kafka" %> build-essential autoconf automake libtool pkg-config<% end %><% if requires_git %> git<% end %>" \
-     && apt-get update \
+  runtimeDeps="<% if target == "kafka" %>krb5-kdc libsasl2-modules-gssapi-mit libsasl2-dev <% end %>" \
+     <% if target == "kafka" %> && export DEBIAN_FRONTEND=noninteractive <% end %> && apt-get update \
      && apt-get upgrade -y \
      && apt-get install \
      -y --no-install-recommends \
-     $buildDeps net-tools \
-    && gem install bundler --version 1.16.2 \
+     $buildDeps $runtimeDeps net-tools \
+    && gem install bundler --version 2.1.2 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \
@@ -32,7 +33,9 @@ COPY Gemfile* /fluentd/
                   $buildDeps \
  && rm -rf /var/lib/apt/lists/* \
     && gem sources --clear-all \
-    && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem
+    && rm -rf /tmp/* /var/tmp/* /usr/lib/ruby/gems/*/cache/*.gem <% if target == "kafka" %> \
+    && ldd $(gem contents rdkafka | grep librdkafka.so) | grep libsasl2.so.2 
+    <% end %> 
 
 # Copy configuration files
 COPY ./conf/fluent.conf /fluentd/etc/

--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -91,7 +91,8 @@ gem "fluent-plugin-remote_syslog"
 gem "fluent-plugin-kubernetes_remote_syslog"
 <% end %>
 <% when "kafka" %>
-gem "fluent-plugin-kafka", "~> 0.7.9"
+gem "rdkafka", "~> 0.7.0"
+gem "fluent-plugin-kafka", "~> 0.12.2"
 gem "snappy", "~> 0.0.15"
 <% when "kinesis" %>
 <% if is_v1 %>


### PR DESCRIPTION
For SASL_SSL with GSSAPI to work with the rdkafka plugin, needed to install a bunch of kerberos related libraries and upgrade the fluent-plugin-kafka to the latest version as rdkafka was not available in 0.7.9. 