### PR TITLE
Update elasticsearch 6 and 7 plugins

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -25,10 +25,10 @@ gem "fluent-plugin-rewrite-tag-filter", "~> 2.2.0"
 <% end %>
 <% case target when "elasticsearch6" %>
 gem "elasticsearch", "~> 6.0"
-gem "fluent-plugin-elasticsearch", "~> 3.5.5"
+gem "fluent-plugin-elasticsearch", "~> 4.0.2"
 <% when "elasticsearch7" %>
 gem "elasticsearch", "~> 7.0"
-gem "fluent-plugin-elasticsearch", "~> 3.7.1"
+gem "fluent-plugin-elasticsearch", "~> 4.0.2"
 gem "elasticsearch-xpack", "~> 7.4.0"
 gem "fluent-plugin-dedot_filter", "~> 1.0"
 <% when "logentries" %>


### PR DESCRIPTION
* ES plugin 3.5.6 is not compatible for Fluentd v1.8.
* The latest ES plugin version is v4.0.2.

Related to https://github.com/uken/fluent-plugin-elasticsearch/issues/712.