### PR TITLE
Update Elasticsearch plugin to v4.0.3

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -19,10 +19,10 @@ gem "fluent-plugin-detect-exceptions", "~> 0.0.12"
 gem "fluent-plugin-rewrite-tag-filter", "~> 2.2.0"
 <% case target when "elasticsearch6" %>
 gem "elasticsearch", "~> 6.0"
-gem "fluent-plugin-elasticsearch", "~> 4.0.2"
+gem "fluent-plugin-elasticsearch", "~> 4.0.3"
 <% when "elasticsearch7" %>
 gem "elasticsearch", "~> 7.0"
-gem "fluent-plugin-elasticsearch", "~> 4.0.2"
+gem "fluent-plugin-elasticsearch", "~> 4.0.3"
 gem "elasticsearch-xpack", "~> 7.4.0"
 gem "fluent-plugin-dedot_filter", "~> 1.0"
 <% when "logentries" %>


### PR DESCRIPTION
Because the previous ES plugin versions contain non-preserving scheme
issue.
elasticsearch-ruby treats scheme information without option.http.scheme
as ephemeral information.
So, https scheme users suffered suddenly fallback to http issue.
Elasticsearch plugin v4.0.3 fixes this issue.

See: https://github.com/uken/fluent-plugin-elasticsearch/pull/713
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>