### PR TITLE
Adopt k8s 1.16 for fluentd-daemonset-elasticsearch and fluentd-daemonset-forward daemonsets

### DIFF
--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -7,6 +7,10 @@ metadata:
     k8s-app: fluentd-logging
     version: v1
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
   template:
     metadata:
       labels:

--- a/fluentd-daemonset-forward.yaml
+++ b/fluentd-daemonset-forward.yaml
@@ -7,6 +7,10 @@ metadata:
     k8s-app: fluentd-logging
     version: v1
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
   template:
     metadata:
       labels:


### PR DESCRIPTION
k8s 1.16 requests to specify selector metadata.
Otherwise, the following errors are occurred:

```
error: error validating "fluentd-daemonset-forward.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

```
error: error validating "fluentd-daemonset-elasticsearch.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
```

I'm using minikube k8s 1.16 environment:

```
% kubectl version
Client Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.3", GitCommit:"b3cbbae08ec52a7fc73d334838e18d17e8512749", GitTreeState:"clean", BuildDate:"2019-11-13T11:23:11Z", GoVersion:"go1.12.12", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:09:08Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
```