### PR TITLE
Add Elasticsearch sniffer class name and use it by default

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -35,6 +35,7 @@
    template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME'] || use_nil}"
    template_file "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_FILE'] || use_nil}"
    template_overwrite "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_OVERWRITE'] || use_default}"
+   sniffer_class_name "#{ENV['FLUENT_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::ElasticsearchSimpleSniffer'}"
 <% if is_v1 %>
    <buffer>
      flush_thread_count "#{ENV['FLUENT_ELASTICSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '8'}"

--- a/templates/entrypoint.sh.erb
+++ b/templates/entrypoint.sh.erb
@@ -17,6 +17,13 @@ if [ -z ${FLUENT_ELASTICSEARCH_SED_DISABLE} ] ; then
     sed -i  '/FLUENT_ELASTICSEARCH_PASSWORD/d' /fluentd/etc/${FLUENTD_CONF}
   fi
 fi
+
+SIMPLE_SNIFFER=$( gem contents fluent-plugin-elasticsearch | grep elasticsearch_simple_sniffer.rb )
+
+if [ -n "$SIMPLE_SNIFFER" -a -f "$SIMPLE_SNIFFER" ] ; then
+    FLUENTD_OPT="$FLUENTD_OPT -r $SIMPLE_SNIFFER"
+fi
+
 <% end %>
 
 exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile ${FLUENTD_OPT}


### PR DESCRIPTION
Because elasticasearch plugin should use elasticsearch-ruby client's sniffering cluster feature which is called every 10000 requests by default and its sniffering feature replaces elasticsearch instances service names with their pod ip addresses.
But, in k8s environment, we should use service name instead of raw ip addresses.

So, in k8s, we should recommend to use SimpleSniffer class for elasticsearch plugin.
WDYT?

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>