### PR TITLE
elasticsearch7: Use TLSv1.2 by default on Elasticsearch7 image

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -21,7 +21,11 @@
    path "#{ENV['FLUENT_ELASTICSEARCH_PATH']}"
    scheme "#{ENV['FLUENT_ELASTICSEARCH_SCHEME'] || 'http'}"
    ssl_verify "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERIFY'] || 'true'}"
+<% if target == "elasticsearch7" %>
+   ssl_version "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERSION'] || 'TLSv1_2'}"
+<% else %>
    ssl_version "#{ENV['FLUENT_ELASTICSEARCH_SSL_VERSION'] || 'TLSv1'}"
+<% end %>
    user "#{ENV['FLUENT_ELASTICSEARCH_USER']}"
    password "#{ENV['FLUENT_ELASTICSEARCH_PASSWORD']}"
    reload_connections "#{ENV['FLUENT_ELASTICSEARCH_RELOAD_CONNECTIONS'] || 'false'}"


### PR DESCRIPTION
For Elasticsearch 7, we should specify `ssl_verson` as  `TLSv1_2` by default.
Because Elasticsearch 7 does not communicate with TLSv1 and SSLv23.

Fixes #357.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>