### PR TITLE
Added support for k8s 1.16 to cloudwatch

### DIFF
--- a/fluentd-daemonset-cloudwatch-rbac.yaml
+++ b/fluentd-daemonset-cloudwatch-rbac.yaml
@@ -45,6 +45,10 @@ metadata:
     k8s-app: fluentd-logging
     version: v1
 spec:
+  selector:
+    matchLabels:
+      k8s-app: fluentd-logging
+      version: v1
   template:
     metadata:
       annotations:


### PR DESCRIPTION
When using the following version of kubectl: 
```
➜ mk version  
Client Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.2", GitCommit:"59603c6e503c87169aea6106f57b9f242f64df89", GitTreeState:"clean", BuildDate:"2020-01-18T23:30:10Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"17", GitVersion:"v1.17.2", GitCommit:"59603c6e503c87169aea6106f57b9f242f64df89", GitTreeState:"clean", BuildDate:"2020-01-18T23:22:30Z", GoVersion:"go1.13.5", Compiler:"gc", Platform:"linux/amd64"}
```

You get the following error when trying to create fluentd-daemonset-cloudwatch-rbac.yaml :
```
➜ mk create -f fluentd-daemonset-cloudwatch-rbac.yaml 
...
error validating "fluentd-daemonset-cloudwatch-rbac.yaml": error validating data: ValidationError(DaemonSet.spec): missing required field "selector" in io.k8s.api.apps.v1.DaemonSetSpec; if you choose to ignore these errors, turn validation off with --validate=false
``` 

Similar to: https://github.com/fluent/fluentd-kubernetes-daemonset/pull/402