### PR TITLE
Allow setting skip_* settings for k8s metadata filter using ENV vars

### DIFF
--- a/templates/conf/kubernetes.conf.erb
+++ b/templates/conf/kubernetes.conf.erb
@@ -194,6 +194,10 @@
   kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || 'https://' + ENV.fetch('KUBERNETES_SERVICE_HOST') + ':' + ENV.fetch('KUBERNETES_SERVICE_PORT') + '/api'}"
   verify_ssl "#{ENV['KUBERNETES_VERIFY_SSL'] || true}"
   ca_file "#{ENV['KUBERNETES_CA_FILE']}"
+  skip_labels "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_LABELS'] || 'false'}"
+  skip_container_metadata "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_CONTAINER_METADATA'] || 'false'}"
+  skip_master_url "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_MASTER_URL'] || 'false'}"
+  skip_namespace_metadata "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_NAMESPACE_METADATA'] || 'false'}"
 </filter>
 
 <% case target when "papertrail" %>


### PR DESCRIPTION
I like that the k8s metadata filter plugin is included by default however I'd also like to be able to tweak the settings without having to overwrite the complete kubernetes.conf. 
Especially the `skip_labels`, `skip_container_metadata`, `skip_master_url` and `skip_namespace_metadata` settings are of interest.
This PR enables users to set these settings with ENV vars. 