### PR TITLE
Update fluent-plugin-google-cloud to 0.8.4

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -33,7 +33,7 @@ gem "fluent-plugin-loggly", "~> 0.0.9"
 gem "aws-sdk-cloudwatchlogs", "~> 1.0"
 gem "fluent-plugin-cloudwatch-logs", "~> 0.8.0"
 <% when "stackdriver" %>
-gem "fluent-plugin-google-cloud", "~> 0.4.10"
+gem "fluent-plugin-google-cloud", "~> 0.8.4"
 <% when "s3" %>
 gem "aws-sdk-s3", "~> 1.0"
 gem "fluent-plugin-s3", "~> 1.1.6"


### PR DESCRIPTION
This is significantly outdated, not sure as to the reason.

This does need to be tested.