### PR TITLE
Add parameter target_index_key in fluent.conf

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -34,6 +34,7 @@
    logstash_dateformat "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_DATEFORMAT'] || '%Y.%m.%d'}"
    logstash_format "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_FORMAT'] || 'true'}"
    index_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_INDEX_NAME'] || 'logstash'}"
+   target_index_key "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_TARGET_INDEX_KEY'] || ''}"
    type_name "#{ENV['FLUENT_ELASTICSEARCH_LOGSTASH_TYPE_NAME'] || 'fluentd'}"
    include_timestamp "#{ENV['FLUENT_ELASTICSEARCH_INCLUDE_TIMESTAMP'] || 'false'}"
    template_name "#{ENV['FLUENT_ELASTICSEARCH_TEMPLATE_NAME'] || use_nil}"


### PR DESCRIPTION
The parameter **target_index_key** tells the plugin to use a key of the record as the name of the index.

If the key is present in the record the value will be used as the index name. If it is not found then it will use **index_name** setting as configured. If the value of **target_index_key** if **blank**, then the plugin will not find the field in the record and use the **index_name** setting.

This feature is usefull in conjunction with *filters* that can be placed in the conf.d folder. For example, this parameter can be used to create a index by namespaces.
