### PR TITLE
Update fluent-plugin-cloudwatch-logs to 0.10.0

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -30,7 +30,7 @@ gem "fluent-plugin-dedot_filter", "~> 1.0"
 gem "fluent-plugin-loggly", "~> 0.0.9"
 <% when "cloudwatch" %>
 gem "aws-sdk-cloudwatchlogs", "~> 1.0"
-gem "fluent-plugin-cloudwatch-logs", "~> 0.9.3"
+gem "fluent-plugin-cloudwatch-logs", "~> 0.10.0"
 <% when "stackdriver" %>
 gem "fluent-plugin-google-cloud", "~> 0.4.10"
 <% when "s3" %>


### PR DESCRIPTION
Update fluent-plugin-cloudwatch-logs to get fix for DescribeLogStreams erroneous calls:
https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/pull/194

For testing, did these commands:
```
  vi templates/Gemfile.erb
  make gemfile    IMAGE_NAME=fluent/fluentd-cloudwatch VERSION=v1.11.0-debian-cloudwatch-1.0 DOCKERFILE=v1.11/debian-cloudwatch
  make dockerfile IMAGE_NAME=fluent/fluentd-cloudwatch VERSION=v1.11.0-debian-cloudwatch-1.0 DOCKERFILE=v1.11/debian-cloudwatch
  make image      IMAGE_NAME=fluent/fluentd-cloudwatch VERSION=v1.11.0-debian-cloudwatch-1.0 DOCKERFILE=v1.11/debian-cloudwatch
  docker run -it -e KUBERNETES_SERVICE_HOST=kubernetes.docker.internal -e KUBERNETES_SERVICE_PORT=6443 fluent/fluentd-cloudwatch:v1.11.0-debian-cloudwatch-1.0
```