### PR TITLE
Update fluent-plugin-cloudwatch-logs to 0.10.0

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -30,7 +30,7 @@ gem "fluent-plugin-dedot_filter", "~> 1.0"
 gem "fluent-plugin-loggly", "~> 0.0.9"
 <% when "cloudwatch" %>
 gem "aws-sdk-cloudwatchlogs", "~> 1.0"
-gem "fluent-plugin-cloudwatch-logs", "~> 0.9.3"
+gem "fluent-plugin-cloudwatch-logs", "~> 0.10.0"
 <% when "stackdriver" %>
 gem "fluent-plugin-google-cloud", "~> 0.4.10"
 <% when "s3" %>


### PR DESCRIPTION
This version of fluent-plugin-cloudwatch-logs fixes a major performance drain, where DescribeLogStreams was being called whenever the update token was incorrect, resulting in throttling by AWS:

https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/issues/192
https://github.com/fluent-plugins-nursery/fluent-plugin-cloudwatch-logs/pull/194

Signed-off-by: Charles Howes <charles.howes@unbounce.com>