### PR TITLE
debian-elasticsaearch7: Use fluent-plugin-elasticsearch 4.4.1

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -21,7 +21,7 @@ gem "elasticsearch", "~> 6.0"
 gem "fluent-plugin-elasticsearch", "~> 4.0.9"
 <% when "elasticsearch7" %>
 gem "elasticsearch", "~> 7.0"
-gem "fluent-plugin-elasticsearch", "~> 4.0.10"
+gem "fluent-plugin-elasticsearch", "~> 4.1.1"
 gem "elasticsearch-xpack", "~> 7.0"
 gem "fluent-plugin-dedot_filter", "~> 1.0"
 <% when "logentries" %>


### PR DESCRIPTION
Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>

fluent-plugin-elasticsearch v4.1.1 can handle `logstash_format` as `true` and `enable_ilm` circumstances.