### PR TITLE
update s3 related gems

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -34,8 +34,8 @@ gem "fluent-plugin-cloudwatch-logs", "~> 0.10.0"
 <% when "stackdriver" %>
 gem "fluent-plugin-google-cloud", "~> 0.4.10"
 <% when "s3" %>
-gem "aws-sdk-s3", "~> 1.0"
-gem "fluent-plugin-s3", "~> 1.1.6"
+gem "aws-sdk-s3", "~> 1.75"
+gem "fluent-plugin-s3", "~> 1.3.0"
 <% when "gcs" %>
 gem "fluent-plugin-gcs", "0.4.0"
 <% when "graylog" %>


### PR DESCRIPTION
We encountered on some bugs with exporting logs to s3, after manually version updating, bugs are disappeared.

`[warn]: section <web_identity_credentials> is not used in <match {kubernetes.var.log.containers.**default**.log,kubernetes.var.log.containers.**nginx-ingress**.log,kubernetes.var.log.containers.**dashboard**.log}>`