### PR TITLE
Rmove needless spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ oc patch ds fluentd -p "spec:
       - name: fluentd
         securityContext:
           privileged: true"
-oc delete pod -l k8s-app = fluentd-logging
+oc delete pod -l k8s-app=fluentd-logging
 ```
 
 This is from [nekop's japanese article](https://nekop.hatenablog.com/entry/2018/04/20/170257).


### PR DESCRIPTION
Fixes #460

The original article does not use spaces around equal symbol.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>