### PR TITLE
Add note for fluentd kubernetes daemonset on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,16 @@ This is from [nekop's japanese article](https://nekop.hatenablog.com/entry/2018/
 
 zookeeper gem doesn't work on Debian 10, so kafka image doesn't include zookeeper gem.
 
+### Windows k8s daemonset doesn't support in this repository
+
+Maintainers don't have k8s experience on Windows.
+Some users create k8s daemonset on Windows:
+
+- https://github.com/bgsilvait/k8s-fluentd-windows
+- https://github.com/k1nger/fluentd-windows-daemon
+
+Please check them out.
+
 ## Maintainers
 
 Some images are contributed by users. If you have a problem/question for following images, ask it to contributors.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ This is from [nekop's japanese article](https://nekop.hatenablog.com/entry/2018/
 
 zookeeper gem doesn't work on Debian 10, so kafka image doesn't include zookeeper gem.
 
-### Windows k8s daemonset doesn't support in this repository
+### Windows k8s daemonset not supported in this repository
 
 Maintainers don't have k8s experience on Windows.
 Some users create k8s daemonset on Windows:

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -171,6 +171,16 @@ This is from [nekop's japanese article](https://nekop.hatenablog.com/entry/2018/
 
 zookeeper gem doesn't work on Debian 10, so kafka image doesn't include zookeeper gem.
 
+### Windows k8s daemonset doesn't support in this repository
+
+Maintainers don't have k8s experience on Windows.
+Some users create k8s daemonset on Windows:
+
+- https://github.com/bgsilvait/k8s-fluentd-windows
+- https://github.com/k1nger/fluentd-windows-daemon
+
+Please check them out.
+
 ## Maintainers
 
 Some images are contributed by users. If you have a problem/question for following images, ask it to contributors.

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -171,7 +171,7 @@ This is from [nekop's japanese article](https://nekop.hatenablog.com/entry/2018/
 
 zookeeper gem doesn't work on Debian 10, so kafka image doesn't include zookeeper gem.
 
-### Windows k8s daemonset doesn't support in this repository
+### Windows k8s daemonset not supported in this repository
 
 Maintainers don't have k8s experience on Windows.
 Some users create k8s daemonset on Windows:


### PR DESCRIPTION
Closes https://github.com/fluent/fluentd-kubernetes-daemonset/issues/375

We don't have experiences for k8s daemonset on Windows
and IIS which is one of the important components on Windows.
So, we can only announce community user created k8s deamonset for
Windows.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>