### PR TITLE
Add missing id attributes

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -151,6 +151,7 @@
 <% when "azureblob"%>
 <match **>
   @type azure-storage-append-blob
+  @id out_azure_storage_append_blob
 
   azure_storage_account         "#{ENV['AZUREBLOB_ACCOUNT_NAME']}"
   azure_storage_access_key      "#{ENV['AZUREBLOB_ACCOUNT_KEY']}"
@@ -177,6 +178,7 @@
 # The gelf plugin assumes input in utf-8
 <filter **>
   @type record_modifier
+  @id graylog_encode_utf8
   char_encoding utf-8
 </filter>
 
@@ -275,6 +277,8 @@
 <% when "splunkhec" %>
 <match **>
   @type splunk_hec
+  @id out_splunk_hec
+
   host "#{ENV['FLUENT_SPLUNK_HEC_HOST'] || nil}"
   port "#{ENV['FLUENT_SPLUNK_HEC_PORT'] || '8089'}"
   token "#{ENV['FLUENT_SPLUNK_HEC_TOKEN'] || nil}"

--- a/templates/conf/kubernetes.conf.erb
+++ b/templates/conf/kubernetes.conf.erb
@@ -5,6 +5,7 @@
 <label @FLUENT_LOG>
   <match fluent.**>
     @type null
+    @id ignore_fluent_logs
   </match>
 </label>
 

--- a/templates/conf/prometheus.conf.erb
+++ b/templates/conf/prometheus.conf.erb
@@ -4,6 +4,7 @@
 # Prometheus metric exposed on 0.0.0.0:24231/metrics
 <source>
   @type prometheus
+  @id in_prometheus
   bind "#{ENV['FLUENTD_PROMETHEUS_BIND'] || '0.0.0.0'}"
   port "#{ENV['FLUENTD_PROMETHEUS_PORT'] || '24231'}"
   metrics_path "#{ENV['FLUENTD_PROMETHEUS_PATH'] || '/metrics'}"
@@ -11,4 +12,5 @@
 
 <source>
   @type prometheus_output_monitor
+  @id in_prometheus_output_monitor
 </source>


### PR DESCRIPTION
This PR sets the [`@id` attribute](https://docs.fluentd.org/configuration/plugin-common-parameters#id) for all sources, filters and outputs that currently do not specify it.

This change should prevent high cardinality data in Prometheus by avoiding `object:<random-id>` values in the `plugin_id` label, as well as make the fluentd logs themselves more readable.