### PR TITLE
Make "watch" from kubernetes plugin configurable

### DIFF
--- a/templates/conf/kubernetes.conf.erb
+++ b/templates/conf/kubernetes.conf.erb
@@ -200,6 +200,7 @@
   skip_container_metadata "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_CONTAINER_METADATA'] || 'false'}"
   skip_master_url "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_MASTER_URL'] || 'false'}"
   skip_namespace_metadata "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_NAMESPACE_METADATA'] || 'false'}"
+  watch "#{ENV['FLUENT_KUBERNETES_WATCH'] || 'true'}"
 </filter>
 
 <% case target when "papertrail" %>


### PR DESCRIPTION
Following https://github.com/fluent/fluentd-kubernetes-daemonset/pull/419, make another option on fluent-plugin-kubernetes_metadata_filter
configurable: watch.

Our fluentd pods are currently affected by an issue described here: https://github.com/fluent/fluentd-kubernetes-daemonset/issues/393. Until the issue is resolved, a proposed workaround is to disable "watch" setting. The workaround was proposed in this comment: https://github.com/fluent/fluentd-kubernetes-daemonset/issues/393#issuecomment-621175135

This commit makes "watch" configurable.