### PR TITLE
Follow the latest bundler platform usecase on Fluentd v1.12.0 images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -178,12 +178,12 @@ dockerfile:
 gemfile:
 	mkdir -p docker-image/$(DOCKERFILE)
 	docker run --rm -i -v $(PWD)/templates/Gemfile.erb:/Gemfile.erb:ro \
-		ruby:alpine3.10 erb -U -T 1 \
+		ruby:alpine erb -U -T 1 \
 			dockerfile='$(DOCKERFILE)' \
 			version='$(VERSION)' \
 		/Gemfile.erb > docker-image/$(DOCKERFILE)/Gemfile
 	docker run --rm -i -v $(PWD)/docker-image/$(DOCKERFILE)/Gemfile:/Gemfile:ro \
-		ruby:alpine3.10 sh -c "apk add --no-cache --quiet git && bundle lock --print" > docker-image/${DOCKERFILE}/Gemfile.lock
+		ruby:alpine sh -c "apk add --no-cache --quiet git && bundle lock --print --remove-platform x86_64-linux-musl --add-platform ruby" > docker-image/${DOCKERFILE}/Gemfile.lock
 
 # Generate entrypoint.sh from template.
 #

--- a/docker-image/v1.12/arm64/debian-azureblob/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-azureblob/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true && bundle config build.nokogiri --use-system-libraries \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-azureblob/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-azureblob/Gemfile.lock
@@ -152,4 +152,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-cloudwatch/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-cloudwatch/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-cloudwatch/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-cloudwatch/Gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-elasticsearch6/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-elasticsearch6/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-elasticsearch6/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-elasticsearch6/Gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-elasticsearch7/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-elasticsearch7/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-elasticsearch7/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-elasticsearch7/Gemfile.lock
@@ -150,4 +150,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-forward/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-forward/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-forward/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-forward/Gemfile.lock
@@ -122,4 +122,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-gcs/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-gcs/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-gcs/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-gcs/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       google-cloud-core (~> 1.2)
       googleauth (~> 0.9)
       mini_mime (~> 1.0)
-    googleauth (0.14.0)
+    googleauth (0.15.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -190,4 +190,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-graylog/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-graylog/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential patch zlib1
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-graylog/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-graylog/Gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-kafka/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-kafka/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-kafka/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-kafka/Gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   snappy (~> 0.0.15)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-kafka2/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-kafka2/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-kafka2/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-kafka2/Gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   snappy (~> 0.0.15)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-kinesis/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-kinesis/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-kinesis/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-kinesis/Gemfile.lock
@@ -145,4 +145,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-logentries/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-logentries/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-logentries/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-logentries/Gemfile.lock
@@ -122,4 +122,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-loggly/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-loggly/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-loggly/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-loggly/Gemfile.lock
@@ -127,4 +127,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-logzio/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-logzio/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-logzio/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-logzio/Gemfile.lock
@@ -127,4 +127,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-papertrail/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-papertrail/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-papertrail/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-papertrail/Gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-s3/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-s3/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-s3/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-s3/Gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-stackdriver/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-stackdriver/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-stackdriver/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-stackdriver/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
-    googleauth (0.14.0)
+    googleauth (0.15.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -175,4 +175,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/arm64/debian-syslog/Dockerfile
+++ b/docker-image/v1.12/arm64/debian-syslog/Dockerfile
@@ -28,7 +28,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/arm64/debian-syslog/Gemfile.lock
+++ b/docker-image/v1.12/arm64/debian-syslog/Gemfile.lock
@@ -129,4 +129,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-azureblob/Dockerfile
+++ b/docker-image/v1.12/debian-azureblob/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true && bundle config build.nokogiri --use-system-libraries \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-azureblob/Gemfile.lock
+++ b/docker-image/v1.12/debian-azureblob/Gemfile.lock
@@ -152,4 +152,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-cloudwatch/Dockerfile
+++ b/docker-image/v1.12/debian-cloudwatch/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-cloudwatch/Gemfile.lock
+++ b/docker-image/v1.12/debian-cloudwatch/Gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-elasticsearch6/Dockerfile
+++ b/docker-image/v1.12/debian-elasticsearch6/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-elasticsearch6/Gemfile.lock
+++ b/docker-image/v1.12/debian-elasticsearch6/Gemfile.lock
@@ -144,4 +144,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-elasticsearch7/Dockerfile
+++ b/docker-image/v1.12/debian-elasticsearch7/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-elasticsearch7/Gemfile.lock
+++ b/docker-image/v1.12/debian-elasticsearch7/Gemfile.lock
@@ -150,4 +150,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-forward/Dockerfile
+++ b/docker-image/v1.12/debian-forward/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-forward/Gemfile.lock
+++ b/docker-image/v1.12/debian-forward/Gemfile.lock
@@ -122,4 +122,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-gcs/Dockerfile
+++ b/docker-image/v1.12/debian-gcs/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-gcs/Gemfile.lock
+++ b/docker-image/v1.12/debian-gcs/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       google-cloud-core (~> 1.2)
       googleauth (~> 0.9)
       mini_mime (~> 1.0)
-    googleauth (0.14.0)
+    googleauth (0.15.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -190,4 +190,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-graylog/Dockerfile
+++ b/docker-image/v1.12/debian-graylog/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential patch zlib1
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-graylog/Gemfile.lock
+++ b/docker-image/v1.12/debian-graylog/Gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-kafka/Dockerfile
+++ b/docker-image/v1.12/debian-kafka/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-kafka/Gemfile.lock
+++ b/docker-image/v1.12/debian-kafka/Gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   snappy (~> 0.0.15)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-kafka2/Dockerfile
+++ b/docker-image/v1.12/debian-kafka2/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-kafka2/Gemfile.lock
+++ b/docker-image/v1.12/debian-kafka2/Gemfile.lock
@@ -140,4 +140,4 @@ DEPENDENCIES
   snappy (~> 0.0.15)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-kinesis/Dockerfile
+++ b/docker-image/v1.12/debian-kinesis/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-kinesis/Gemfile.lock
+++ b/docker-image/v1.12/debian-kinesis/Gemfile.lock
@@ -145,4 +145,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-logentries/Dockerfile
+++ b/docker-image/v1.12/debian-logentries/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-logentries/Gemfile.lock
+++ b/docker-image/v1.12/debian-logentries/Gemfile.lock
@@ -122,4 +122,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-loggly/Dockerfile
+++ b/docker-image/v1.12/debian-loggly/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-loggly/Gemfile.lock
+++ b/docker-image/v1.12/debian-loggly/Gemfile.lock
@@ -127,4 +127,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-logzio/Dockerfile
+++ b/docker-image/v1.12/debian-logzio/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-logzio/Gemfile.lock
+++ b/docker-image/v1.12/debian-logzio/Gemfile.lock
@@ -127,4 +127,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-papertrail/Dockerfile
+++ b/docker-image/v1.12/debian-papertrail/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-papertrail/Gemfile.lock
+++ b/docker-image/v1.12/debian-papertrail/Gemfile.lock
@@ -130,4 +130,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-s3/Dockerfile
+++ b/docker-image/v1.12/debian-s3/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-s3/Gemfile.lock
+++ b/docker-image/v1.12/debian-s3/Gemfile.lock
@@ -148,4 +148,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-stackdriver/Dockerfile
+++ b/docker-image/v1.12/debian-stackdriver/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-stackdriver/Gemfile.lock
+++ b/docker-image/v1.12/debian-stackdriver/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       multi_json (~> 1.10)
       retriable (~> 1.4)
       signet (~> 0.6)
-    googleauth (0.14.0)
+    googleauth (0.15.0)
       faraday (>= 0.17.3, < 2.0)
       jwt (>= 1.4, < 3.0)
       memoist (~> 0.16)
@@ -175,4 +175,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/docker-image/v1.12/debian-syslog/Dockerfile
+++ b/docker-image/v1.12/debian-syslog/Dockerfile
@@ -20,7 +20,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.12/debian-syslog/Gemfile.lock
+++ b/docker-image/v1.12/debian-syslog/Gemfile.lock
@@ -129,4 +129,4 @@ DEPENDENCIES
   oj (= 3.11.0)
 
 BUNDLED WITH
-   2.1.4
+   2.2.3

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -36,7 +36,7 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev<% if target == "graylog" %>
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.1.4 \
+    && gem install bundler --version 2.2.6 \
     && bundle config silence_root_warning true<% if target == "azureblob" %> && bundle config build.nokogiri --use-system-libraries<% end %> \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \


### PR DESCRIPTION
The latest bundler 2.2.x uses platform information on Gemfile.lock.
We should specify ruby as platform instead of x86_64-linux-musl.

Follows up #526.

Signed-off-by: Hiroshi Hatake <hatake@clear-code.com>