### PR TITLE
Refactor/kubernetes configs split

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ release-all:
 # Usage:
 #	make src [DOCKERFILE=] [VERSION=] [TAGS=t1,t2,...]
 
-src: dockerfile gemfile fluent.conf systemd.conf prometheus.conf kubernetes.conf plugins post-push-hook post-checkout-hook entrypoint.sh cluster-autoscaler.conf containers.conf docker.conf etcd.conf glbc.conf kube-apiserver-audit.conf kube-apiserver.conf kube-controller-manager.conf kubelet.conf kube-proxy.conf kube-scheduler.conf rescheduler.conf salt.conf startupscript.conf
+src: dockerfile gemfile fluent.conf systemd.conf prometheus.conf kubernetes.conf plugins post-push-hook post-checkout-hook entrypoint.sh cluster-autoscaler.conf containers.conf docker.conf etcd.conf glbc.conf kube-apiserver-audit.conf kube-apiserver.conf kube-controller-manager.conf kube-proxy.conf kube-scheduler.conf kubelet.conf rescheduler.conf salt.conf startupscript.conf
 
 # Generate sources for all supported Docker images.
 #
@@ -238,6 +238,7 @@ kubernetes.conf-all:
 	make container-image-template-all FILE=kubernetes.conf
 	cp $(PWD)/templates/conf/tail_container_parse.conf docker-image/$(DOCKERFILE)/conf
 
+
 cluster-autoscaler.conf:
 	make container-image-template FILE=conf/kubernetes/cluster-autoscaler.conf
 containers.conf:
@@ -266,6 +267,7 @@ salt.conf:
 	make container-image-template FILE=conf/kubernetes/salt.conf
 startupscript.conf:
 	make container-image-template FILE=conf/kubernetes/startupscript.conf
+
 
 systemd.conf:
 	make container-image-template FILE=conf/systemd.conf

--- a/Makefile
+++ b/Makefile
@@ -79,23 +79,21 @@ eq = $(if $(or $(1),$(2)),$(and $(findstring $(1),$(2)),\
 
 ## Docker image management
 
+no-cache-arg = $(if $(call eq, $(no-cache), yes), --no-cache, $(empty))
+
 # Build Docker image.
 #
 # Usage:
 #	make image [no-cache=(yes|no)] [DOCKERFILE=] [VERSION=]
-
-no-cache-arg = $(if $(call eq, $(no-cache), yes), --no-cache, $(empty))
-
 image:
 	docker build $(no-cache-arg) -t $(IMAGE_NAME):$(VERSION) docker-image/$(DOCKERFILE)
+
+parsed-tags = $(subst $(comma), $(space), $(TAGS))
 
 # Tag Docker image with given tags.
 #
 # Usage:
 #	make tags [VERSION=] [TAGS=t1,t2,...]
-
-parsed-tags = $(subst $(comma), $(space), $(TAGS))
-
 tags:
 	(set -e ; $(foreach tag, $(parsed-tags), \
 		docker tag $(IMAGE_NAME):$(VERSION) $(IMAGE_NAME):$(tag) ; \
@@ -105,7 +103,6 @@ tags:
 #
 # Usage:
 #	make push [TAGS=t1,t2,...]
-
 push:
 	(set -e ; $(foreach tag, $(parsed-tags), \
 		docker push $(IMAGE_NAME):$(tag) ; \
@@ -115,14 +112,12 @@ push:
 #
 # Usage:
 #	make release [no-cache=(yes|no)] [DOCKERFILE=] [VERSION=] [TAGS=t1,t2,...]
-
 release: | image tags push
 
 # Make manual release of all supported Docker images to Docker Hub.
 #
 # Usage:
 #	make release-all [no-cache=(yes|no)]
-
 release-all:
 	(set -e ; $(foreach img,$(ALL_IMAGES), \
 		make release no-cache=$(no-cache) \
@@ -139,14 +134,12 @@ release-all:
 #
 # Usage:
 #	make src [DOCKERFILE=] [VERSION=] [TAGS=t1,t2,...]
-
 src: dockerfile gemfile fluent.conf systemd.conf prometheus.conf kubernetes.conf plugins post-push-hook post-checkout-hook entrypoint.sh cluster-autoscaler.conf containers.conf docker.conf etcd.conf glbc.conf kube-apiserver-audit.conf kube-apiserver.conf kube-controller-manager.conf kube-proxy.conf kube-scheduler.conf kubelet.conf rescheduler.conf salt.conf startupscript.conf
 
 # Generate sources for all supported Docker images.
 #
 # Usage:
 #	make src-all
-
 src-all: README.md
 	(set -e ; $(foreach img,$(ALL_IMAGES), \
 		make src \
@@ -160,7 +153,6 @@ src-all: README.md
 #
 # Usage:
 #	make container-image-template [FILE=] [DOCKERFILE=] [VERSION=]
-
 container-image-template:
 	mkdir -p docker-image/$(DOCKERFILE)/$(dir $(FILE))
 	docker run --rm -i -v $(PWD)/templates/$(FILE).erb:/$(basename $(FILE)).erb:ro \
@@ -169,14 +161,13 @@ container-image-template:
 			version='$(VERSION)' \
 		/$(basename $(FILE)).erb > docker-image/$(DOCKERFILE)/$(FILE)
 
-# Render the given erb template for all images.
+# Execute the given TARGET for each images
 #
 # Usage:
-#	make container-image-template [FILE=] [DOCKERFILE=] [VERSION=]
-
-container-image-template-all:
+#	make each-image TARGET=
+each-image:
 	(set -e ; $(foreach img,$(ALL_IMAGES), \
-		make container-image-template $(FILE) \
+		make $(TARGET) \
 			DOCKERFILE=$(word 1,$(subst :, ,$(img))) \
 			VERSION=$(word 1,$(subst $(comma), ,\
 			                 $(word 2,$(subst :, ,$(img))))) ; \
@@ -187,12 +178,11 @@ container-image-template-all:
 #
 # Usage:
 #	make dockerfile [DOCKERFILE=] [VERSION=]
-
 dockerfile:
 	make container-image-template FILE=Dockerfile
 	cp $(PWD)/templates/.dockerignore docker-image/$(DOCKERFILE)/.dockerignore
 dockerfile-all:
-	make container-image-template-all FILE=dockerfile
+	make each-image TARGET=dockerfile
 
 # Generate Gemfile and Gemfile.lock from template.
 #
@@ -202,78 +192,131 @@ gemfile:
 	make container-image-template FILE=Gemfile
 	docker run --rm -i -v $(PWD)/docker-image/$(DOCKERFILE)/Gemfile:/Gemfile:ro \
 		ruby:alpine sh -c "apk add --no-cache --quiet git && bundle lock --print --remove-platform x86_64-linux-musl --add-platform ruby" > docker-image/${DOCKERFILE}/Gemfile.lock
+
+# Generate Gemfile and Gemfile.lock from template for all supported Docker images.
+#
+# Usage:
+#	make gemfile-all
 gemfile-all:
-	make container-image-template-all FILE=gemfile
+	make each-image TARGET=gemfile
 
 # Generate entrypoint.sh from template.
 #
 # Usage:
 #	make entrypoint.sh [DOCKERFILE=] [VERSION=]
-
 entrypoint.sh:
 	make container-image-template FILE=entrypoint.sh
 	chmod 755 docker-image/$(DOCKERFILE)/entrypoint.sh
+
+# Generate entrypoint.sh from template for all supported Docker images.
+#
+# Usage:
+#	make entrypoint.sh-all
 entrypoint.sh-all:
-	make container-image-template-all FILE=entrypoint.sh
+	make each-image TARGET=entrypoint.sh
 
 # Generate fluent.conf from template.
 #
 # Usage:
 #	make fluent.conf [DOCKERFILE=] [VERSION=]
-
 fluent.conf:
 	make container-image-template FILE=conf/fluent.conf
 fluent.conf-all:
-	make container-image-template-all FILE=fluent.conf
+	make each-image TARGET=fluent.conf
 
 # Generate kubernetes.conf from template.
 #
 # Usage:
 #	make kubernetes.conf [DOCKERFILE=] [VERSION=]
-
 kubernetes.conf:
 	make container-image-template FILE=conf/kubernetes.conf
 	cp $(PWD)/templates/conf/tail_container_parse.conf docker-image/$(DOCKERFILE)/conf
 kubernetes.conf-all:
-	make container-image-template-all FILE=kubernetes.conf
-	cp $(PWD)/templates/conf/tail_container_parse.conf docker-image/$(DOCKERFILE)/conf
-
+	make each-image TARGET=kubernetes.conf
 
 cluster-autoscaler.conf:
 	make container-image-template FILE=conf/kubernetes/cluster-autoscaler.conf
+cluster-autoscaler.conf-all:
+	make each-image TARGET=cluster-autoscaler.conf
+
 containers.conf:
 	make container-image-template FILE=conf/kubernetes/containers.conf
+containers.conf-all:
+	make each-image TARGET=containers.conf
+
 docker.conf:
 	make container-image-template FILE=conf/kubernetes/docker.conf
+docker.conf-all:
+	make each-image TARGET=docker.conf
+
 etcd.conf:
 	make container-image-template FILE=conf/kubernetes/etcd.conf
+etcd.conf-all:
+	make each-image TARGET=etcd.conf
+
 glbc.conf:
 	make container-image-template FILE=conf/kubernetes/glbc.conf
+glbc.conf-all:
+	make each-image TARGET=glbc.conf
+
 kube-apiserver-audit.conf:
 	make container-image-template FILE=conf/kubernetes/kube-apiserver-audit.conf
+kube-apiserver-audit.conf-all:
+	make each-image TARGET=kube-apiserver-audit.conf
+
 kube-apiserver.conf:
 	make container-image-template FILE=conf/kubernetes/kube-apiserver.conf
+kube-apiserver.conf-all:
+	make each-image TARGET=kube-apiserver.conf
+
 kube-controller-manager.conf:
 	make container-image-template FILE=conf/kubernetes/kube-controller-manager.conf
+kube-controller-manager.conf-all:
+	make each-image TARGET=kube-controller-manager.conf
+
 kubelet.conf:
 	make container-image-template FILE=conf/kubernetes/kubelet.conf
+kubelet.conf-all:
+	make each-image TARGET=kubelet.conf
+
 kube-proxy.conf:
 	make container-image-template FILE=conf/kubernetes/kube-proxy.conf
+kube-proxy.conf-all:
+	make each-image TARGET=kube-proxy.conf
+
 kube-scheduler.conf:
 	make container-image-template FILE=conf/kubernetes/kube-scheduler.conf
+kube-scheduler.conf-all:
+	make each-image TARGET=kube-scheduler.conf
+
 rescheduler.conf:
 	make container-image-template FILE=conf/kubernetes/rescheduler.conf
+rescheduler.conf-all:
+	make each-image TARGET=rescheduler.conf
+
 salt.conf:
 	make container-image-template FILE=conf/kubernetes/salt.conf
+salt.conf-all:
+	make each-image TARGET=salt.conf
+
 startupscript.conf:
 	make container-image-template FILE=conf/kubernetes/startupscript.conf
+startupscript.conf-all:
+	make each-image TARGET=startupscript.conf
+
 
 
 systemd.conf:
 	make container-image-template FILE=conf/systemd.conf
+systemd.conf-all:
+	make each-image TARGET=systemd.conf
+
 
 prometheus.conf:
 	make container-image-template FILE=conf/prometheus.conf
+prometheus.conf-all:
+	make each-image TARGET=prometheus.conf
+
 
 README.md: templates/README.md.erb
 	docker run --rm -i -v $(PWD)/templates/README.md.erb:/README.md.erb:ro \
@@ -285,11 +328,20 @@ README.md: templates/README.md.erb
 #
 # Usage:
 #    make plugins [DOCKERFILE=]
-
 plugins:
 	mkdir -p docker-image/$(DOCKERFILE)/plugins
 	cp -R plugins/$(FLUENTD_VERSION)/shared/. docker-image/$(DOCKERFILE)/plugins/
 	cp -R plugins/$(FLUENTD_VERSION)/$(TARGET)/. docker-image/$(DOCKERFILE)/plugins/
+
+# copy plugins required for all supported Docker images.
+#
+# Usage:
+#	make plugins-all
+plugins-all:
+	(set -e ; $(foreach img,$(ALL_IMAGES), \
+		make plugins \
+			DOCKERFILE=$(word 1,$(subst :, ,$(img))) ; \
+	))
 
 # Create `post_checkout` Docker Hub hook.
 #
@@ -301,10 +353,9 @@ plugins:
 #
 # Usage:
 #	make post-checkout-hook [DOCKERFILE=]
-
 post-checkout-hook:
 	if [ -n "$(findstring /arm64/,$(DOCKERFILE))" ]; then \
-		mkdir -p $(DOCKERFILE)/hooks; \
+		mkdir -p docker-image/$(DOCKERFILE)/hooks; \
 		docker run --rm -i -v $(PWD)/templates/post_checkout.erb:/post_checkout.erb:ro \
 			ruby:alpine erb -U \
 				dockerfile='$(DOCKERFILE)' \
@@ -316,14 +367,8 @@ post-checkout-hook:
 #
 # Usage:
 #	make post-checkout-hook-all
-
 post-checkout-hook-all:
-	(set -e ; $(foreach img,$(ALL_IMAGES), \
-		make post-checkout-hook \
-			DOCKERFILE=$(word 1,$(subst :, ,$(img))) ; \
-	))
-
-
+	make each-image TARGET=post-checkout-hook
 
 # Create `post_push` Docker Hub hook.
 #
@@ -343,17 +388,6 @@ post-push-hook:
 			image_tags='$(TAGS)' \
 		/post_push.erb > docker-image/$(DOCKERFILE)/hooks/post_push
 
-# copy plugins required for all supported Docker images.
-#
-# Usage:
-#	make plugins-all
-
-plugins-all:
-	(set -e ; $(foreach img,$(ALL_IMAGES), \
-		make plugins \
-			DOCKERFILE=$(word 1,$(subst :, ,$(img))) ; \
-	))
-
 # Create `post_push` Docker Hub hook for all supported Docker images.
 #
 # Usage:
@@ -370,12 +404,29 @@ post-push-hook-all:
 .PHONY: image tags push \
         release release-all \
         src src-all \
+        container-image-template each-image \
         dockerfile dockerfile-all \
         gemfile gemfile-all \
         entrypoint.sh entrypoint.sh-all \
         fluent.conf fluent.conf-all \
         kubernetes.conf kubernetes.conf-all\
+        cluster-autoscaler.conf cluster-autoscaler.conf-all \
+        containers.conf containers.conf-all \
+        docker.conf docker.conf-all \
+        etcd.conf etcd.conf-all \
+        glbc.conf glbc.conf-all \
+        kube-apiserver-audit.conf kube-apiserver-audit.conf-all \
+        kube-apiserver.conf kube-apiserver.conf-all \
+        kube-controller-manager.conf kube-controller-manager.conf-all \
+        kubelet.conf kubelet.conf-all \
+        kube-proxy.conf kube-proxy.conf-all \
+        kube-scheduler.conf kube-scheduler.conf-all \
+        rescheduler.conf rescheduler.conf-all \
+        salt.conf salt.conf-all \
+        startupscript.conf startupscript.conf-all \
+        systemd.conf systemd.conf-all \
+        prometheus.conf prometheus.conf-all \
         plugins plugins-all \
-        post-push-hook post-push-hook-all \
         post-checkout-hook post-checkout-hook-all \
+        post-push-hook post-push-hook-all \
 	README.md

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ release-all:
 # Usage:
 #	make src [DOCKERFILE=] [VERSION=] [TAGS=t1,t2,...]
 
-src: dockerfile gemfile fluent.conf systemd.conf prometheus.conf kubernetes.conf plugins post-push-hook post-checkout-hook entrypoint.sh
+src: dockerfile gemfile fluent.conf systemd.conf prometheus.conf kubernetes.conf plugins post-push-hook post-checkout-hook entrypoint.sh cluster-autoscaler.conf containers.conf docker.conf etcd.conf glbc.conf kube-apiserver-audit.conf kube-apiserver.conf kube-controller-manager.conf kubelet.conf kube-proxy.conf kube-scheduler.conf rescheduler.conf salt.conf startupscript.conf
 
 # Generate sources for all supported Docker images.
 #
@@ -237,6 +237,35 @@ kubernetes.conf:
 kubernetes.conf-all:
 	make container-image-template-all FILE=kubernetes.conf
 	cp $(PWD)/templates/conf/tail_container_parse.conf docker-image/$(DOCKERFILE)/conf
+
+cluster-autoscaler.conf:
+	make container-image-template FILE=conf/kubernetes/cluster-autoscaler.conf
+containers.conf:
+	make container-image-template FILE=conf/kubernetes/containers.conf
+docker.conf:
+	make container-image-template FILE=conf/kubernetes/docker.conf
+etcd.conf:
+	make container-image-template FILE=conf/kubernetes/etcd.conf
+glbc.conf:
+	make container-image-template FILE=conf/kubernetes/glbc.conf
+kube-apiserver-audit.conf:
+	make container-image-template FILE=conf/kubernetes/kube-apiserver-audit.conf
+kube-apiserver.conf:
+	make container-image-template FILE=conf/kubernetes/kube-apiserver.conf
+kube-controller-manager.conf:
+	make container-image-template FILE=conf/kubernetes/kube-controller-manager.conf
+kubelet.conf:
+	make container-image-template FILE=conf/kubernetes/kubelet.conf
+kube-proxy.conf:
+	make container-image-template FILE=conf/kubernetes/kube-proxy.conf
+kube-scheduler.conf:
+	make container-image-template FILE=conf/kubernetes/kube-scheduler.conf
+rescheduler.conf:
+	make container-image-template FILE=conf/kubernetes/rescheduler.conf
+salt.conf:
+	make container-image-template FILE=conf/kubernetes/salt.conf
+startupscript.conf:
+	make container-image-template FILE=conf/kubernetes/startupscript.conf
 
 systemd.conf:
 	make container-image-template FILE=conf/systemd.conf

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -55,6 +55,7 @@ COPY ./conf/systemd.conf /fluentd/etc/
 COPY ./conf/kubernetes.conf /fluentd/etc/
 COPY ./conf/prometheus.conf /fluentd/etc/
 COPY ./conf/tail_container_parse.conf /fluentd/etc/
+COPY ./conf/kubernetes/*.conf /fluentd/etc/kubernetes/
 RUN touch /fluentd/etc/disable.conf
 
 # Copy plugins

--- a/templates/conf/kubernetes.conf.erb
+++ b/templates/conf/kubernetes.conf.erb
@@ -20,172 +20,21 @@
   @include tail_container_parse.conf
 </source>
 
-<source>
-  @type tail
-  @id in_tail_minion
-  path /var/log/salt/minion
-  pos_file /var/log/fluentd-salt.pos
-  tag salt
-  <parse>
-    @type regexp
-    expression /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
-    time_format %Y-%m-%d %H:%M:%S
-  </parse>
-</source>
+@include kubernetes/cluster-autoscaler.conf
+@include kubernetes/containers.conf
+@include kubernetes/docker.conf
+@include kubernetes/etcd.conf
+@include kubernetes/glbc.conf
+@include kubernetes/kube-apiserver-audit.conf
+@include kubernetes/kube-apiserver.conf
+@include kubernetes/kube-controller-manager.conf
+@include kubernetes/kube-proxy.conf
+@include kubernetes/kube-scheduler.conf
+@include kubernetes/kubelet.conf
+@include kubernetes/rescheduler.conf
+@include kubernetes/salt.conf
+@include kubernetes/startupscript.conf
 
-<source>
-  @type tail
-  @id in_tail_startupscript
-  path /var/log/startupscript.log
-  pos_file /var/log/fluentd-startupscript.log.pos
-  tag startupscript
-  <parse>
-    @type syslog
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_docker
-  path /var/log/docker.log
-  pos_file /var/log/fluentd-docker.log.pos
-  tag docker
-  <parse>
-    @type regexp
-    expression /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_etcd
-  path /var/log/etcd.log
-  pos_file /var/log/fluentd-etcd.log.pos
-  tag etcd
-  <parse>
-    @type none
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_kubelet
-  multiline_flush_interval 5s
-  path /var/log/kubelet.log
-  pos_file /var/log/fluentd-kubelet.log.pos
-  tag kubelet
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_kube_proxy
-  multiline_flush_interval 5s
-  path /var/log/kube-proxy.log
-  pos_file /var/log/fluentd-kube-proxy.log.pos
-  tag kube-proxy
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_kube_apiserver
-  multiline_flush_interval 5s
-  path /var/log/kube-apiserver.log
-  pos_file /var/log/fluentd-kube-apiserver.log.pos
-  tag kube-apiserver
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_kube_controller_manager
-  multiline_flush_interval 5s
-  path /var/log/kube-controller-manager.log
-  pos_file /var/log/fluentd-kube-controller-manager.log.pos
-  tag kube-controller-manager
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_kube_scheduler
-  multiline_flush_interval 5s
-  path /var/log/kube-scheduler.log
-  pos_file /var/log/fluentd-kube-scheduler.log.pos
-  tag kube-scheduler
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_rescheduler
-  multiline_flush_interval 5s
-  path /var/log/rescheduler.log
-  pos_file /var/log/fluentd-rescheduler.log.pos
-  tag rescheduler
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_glbc
-  multiline_flush_interval 5s
-  path /var/log/glbc.log
-  pos_file /var/log/fluentd-glbc.log.pos
-  tag glbc
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-<source>
-  @type tail
-  @id in_tail_cluster_autoscaler
-  multiline_flush_interval 5s
-  path /var/log/cluster-autoscaler.log
-  pos_file /var/log/fluentd-cluster-autoscaler.log.pos
-  tag cluster-autoscaler
-  <parse>
-    @type kubernetes
-  </parse>
-</source>
-
-# Example:
-# 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
-# 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
-<source>
-  @type tail
-  @id in_tail_kube_apiserver_audit
-  multiline_flush_interval 5s
-  path /var/log/kubernetes/kube-apiserver-audit.log
-  pos_file /var/log/kube-apiserver-audit.log.pos
-  tag kube-apiserver-audit
-  <parse>
-    @type multiline
-    format_firstline /^\S+\s+AUDIT:/
-    # Fields must be explicitly captured by name to be parsed into the record.
-    # Fields may not always be present, and order may change, so this just looks
-    # for a list of key="\"quoted\" value" pairs separated by spaces.
-    # Unknown fields are ignored.
-    # Note: We can't separate query/response lines as format1/format2 because
-    #       they don't always come one after the other for a given query.
-    format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
-    time_format %Y-%m-%dT%T.%L%Z
-  </parse>
-</source>
 
 <filter kubernetes.**>
   @type kubernetes_metadata

--- a/templates/conf/kubernetes/cluster-autoscaler.conf.erb
+++ b/templates/conf/kubernetes/cluster-autoscaler.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_cluster_autoscaler
+  multiline_flush_interval 5s
+  path /var/log/cluster-autoscaler.log
+  pos_file /var/log/fluentd-cluster-autoscaler.log.pos
+  tag cluster-autoscaler
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/containers.conf.erb
+++ b/templates/conf/kubernetes/containers.conf.erb
@@ -1,0 +1,14 @@
+
+<source>
+@type tail
+@id in_tail_container_logs
+path /var/log/containers/*.log
+pos_file /var/log/fluentd-containers.log.pos
+tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
+exclude_path "#{ENV['FLUENT_CONTAINER_TAIL_EXCLUDE_PATH'] || use_default}"
+read_from_head true
+<parse>
+  @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
+  time_format %Y-%m-%dT%H:%M:%S.%NZ
+</parse>
+</source>

--- a/templates/conf/kubernetes/docker.conf.erb
+++ b/templates/conf/kubernetes/docker.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_docker
+  path /var/log/docker.log
+  pos_file /var/log/fluentd-docker.log.pos
+  tag docker
+  <parse>
+    @type regexp
+    expression /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
+  </parse>
+</source>

--- a/templates/conf/kubernetes/etcd.conf.erb
+++ b/templates/conf/kubernetes/etcd.conf.erb
@@ -1,0 +1,10 @@
+<source>
+  @type tail
+  @id in_tail_etcd
+  path /var/log/etcd.log
+  pos_file /var/log/fluentd-etcd.log.pos
+  tag etcd
+  <parse>
+    @type none
+  </parse>
+</source>

--- a/templates/conf/kubernetes/glbc.conf.erb
+++ b/templates/conf/kubernetes/glbc.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_glbc
+  multiline_flush_interval 5s
+  path /var/log/glbc.log
+  pos_file /var/log/fluentd-glbc.log.pos
+  tag glbc
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/kube-apiserver-audit.conf.erb
+++ b/templates/conf/kubernetes/kube-apiserver-audit.conf.erb
@@ -1,0 +1,23 @@
+# Example:
+# 2017-02-09T00:15:57.992775796Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" ip="104.132.1.72" method="GET" user="kubecfg" as="<self>" asgroups="<lookup>" namespace="default" uri="/api/v1/namespaces/default/pods"
+# 2017-02-09T00:15:57.993528822Z AUDIT: id="90c73c7c-97d6-4b65-9461-f94606ff825f" response="200"
+<source>
+  @type tail
+  @id in_tail_kube_apiserver_audit
+  multiline_flush_interval 5s
+  path /var/log/kubernetes/kube-apiserver-audit.log
+  pos_file /var/log/kube-apiserver-audit.log.pos
+  tag kube-apiserver-audit
+  <parse>
+    @type multiline
+    format_firstline /^\S+\s+AUDIT:/
+    # Fields must be explicitly captured by name to be parsed into the record.
+    # Fields may not always be present, and order may change, so this just looks
+    # for a list of key="\"quoted\" value" pairs separated by spaces.
+    # Unknown fields are ignored.
+    # Note: We can't separate query/response lines as format1/format2 because
+    #       they don't always come one after the other for a given query.
+    format1 /^(?<time>\S+) AUDIT:(?: (?:id="(?<id>(?:[^"\\]|\\.)*)"|ip="(?<ip>(?:[^"\\]|\\.)*)"|method="(?<method>(?:[^"\\]|\\.)*)"|user="(?<user>(?:[^"\\]|\\.)*)"|groups="(?<groups>(?:[^"\\]|\\.)*)"|as="(?<as>(?:[^"\\]|\\.)*)"|asgroups="(?<asgroups>(?:[^"\\]|\\.)*)"|namespace="(?<namespace>(?:[^"\\]|\\.)*)"|uri="(?<uri>(?:[^"\\]|\\.)*)"|response="(?<response>(?:[^"\\]|\\.)*)"|\w+="(?:[^"\\]|\\.)*"))*/
+    time_format %Y-%m-%dT%T.%L%Z
+  </parse>
+</source>

--- a/templates/conf/kubernetes/kube-apiserver.conf.erb
+++ b/templates/conf/kubernetes/kube-apiserver.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_kube_apiserver
+  multiline_flush_interval 5s
+  path /var/log/kube-apiserver.log
+  pos_file /var/log/fluentd-kube-apiserver.log.pos
+  tag kube-apiserver
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/kube-controller-manager.conf.erb
+++ b/templates/conf/kubernetes/kube-controller-manager.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_kube_controller_manager
+  multiline_flush_interval 5s
+  path /var/log/kube-controller-manager.log
+  pos_file /var/log/fluentd-kube-controller-manager.log.pos
+  tag kube-controller-manager
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/kube-proxy.conf.erb
+++ b/templates/conf/kubernetes/kube-proxy.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_kube_proxy
+  multiline_flush_interval 5s
+  path /var/log/kube-proxy.log
+  pos_file /var/log/fluentd-kube-proxy.log.pos
+  tag kube-proxy
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/kube-scheduler.conf.erb
+++ b/templates/conf/kubernetes/kube-scheduler.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_kube_scheduler
+  multiline_flush_interval 5s
+  path /var/log/kube-scheduler.log
+  pos_file /var/log/fluentd-kube-scheduler.log.pos
+  tag kube-scheduler
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/kubelet.conf.erb
+++ b/templates/conf/kubernetes/kubelet.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_kubelet
+  multiline_flush_interval 5s
+  path /var/log/kubelet.log
+  pos_file /var/log/fluentd-kubelet.log.pos
+  tag kubelet
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/rescheduler.conf.erb
+++ b/templates/conf/kubernetes/rescheduler.conf.erb
@@ -1,0 +1,11 @@
+<source>
+  @type tail
+  @id in_tail_rescheduler
+  multiline_flush_interval 5s
+  path /var/log/rescheduler.log
+  pos_file /var/log/fluentd-rescheduler.log.pos
+  tag rescheduler
+  <parse>
+    @type kubernetes
+  </parse>
+</source>

--- a/templates/conf/kubernetes/salt.conf.erb
+++ b/templates/conf/kubernetes/salt.conf.erb
@@ -1,0 +1,13 @@
+
+<source>
+  @type tail
+  @id in_tail_minion
+  path /var/log/salt/minion
+  pos_file /var/log/fluentd-salt.pos
+  tag salt
+  <parse>
+    @type regexp
+    expression /^(?<time>[^ ]* [^ ,]*)[^\[]*\[[^\]]*\]\[(?<severity>[^ \]]*) *\] (?<message>.*)$/
+    time_format %Y-%m-%d %H:%M:%S
+  </parse>
+</source>

--- a/templates/conf/kubernetes/startupscript.conf.erb
+++ b/templates/conf/kubernetes/startupscript.conf.erb
@@ -1,0 +1,10 @@
+<source>
+  @type tail
+  @id in_tail_startupscript
+  path /var/log/startupscript.log
+  pos_file /var/log/fluentd-startupscript.log.pos
+  tag startupscript
+  <parse>
+    @type syslog
+  </parse>
+</source>


### PR DESCRIPTION
This PR starts with a refactor of the makefile to mutualize redundant parts, to reduce the overall makefile size and increase its maintainability.

Then, each kubernetes source is splitted in its own erb.

Closes #531 
Facilitate resolution of #519 

Feedbacks welcome. More work related to #519  coming next. (I already have the fluentd conf somewhere)