### PR TITLE
Emphasize what image is supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,42 +14,112 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 #### Current stable
 
 ##### x86_64 images
-- `v1.12.0-debian-azureblob-1.1,v1.12-debian-azureblob-1` [docker-image/v1.12/debian-azureblob/Dockerfile](docker-image/v1.12/debian-azureblob/Dockerfile)
-- `v1.12.0-debian-elasticsearch7-1.0,v1.12-debian-elasticsearch7-1,v1-debian-elasticsearch` [docker-image/v1.12/debian-elasticsearch7/Dockerfile](docker-image/v1.12/debian-elasticsearch7/Dockerfile)
-- `v1.12.0-debian-elasticsearch6-1.0,v1.12-debian-elasticsearch6-1` [docker-image/v1.12/debian-elasticsearch6/Dockerfile](docker-image/v1.12/debian-elasticsearch6/Dockerfile)
-- `v1.12.0-debian-loggly-1.0,v1.12-debian-loggly-1` [docker-image/v1.12/debian-loggly/Dockerfile](docker-image/v1.12/debian-loggly/Dockerfile)
-- `v1.12.0-debian-logentries-1.0,v1.12-debian-logentries-1` [docker-image/v1.12/debian-logentries/Dockerfile](docker-image/v1.12/debian-logentries/Dockerfile)
-- `v1.12.0-debian-cloudwatch-1.2,v1.12-debian-cloudwatch-1` [docker-image/v1.12/debian-cloudwatch/Dockerfile](docker-image/v1.12/debian-cloudwatch/Dockerfile)
-- `v1.12.0-debian-stackdriver-1.0,v1.12-debian-stackdriver-1` [docker-image/v1.12/debian-stackdriver/Dockerfile](docker-image/v1.12/debian-stackdriver/Dockerfile)
-- `v1.12.0-debian-s3-1.0,v1.12-debian-s3-1` [docker-image/v1.12/debian-s3/Dockerfile](docker-image/v1.12/debian-s3/Dockerfile)
-- `v1.12.0-debian-syslog-1.0,v1.12-debian-syslog-1` [docker-image/v1.12/debian-syslog/Dockerfile](docker-image/v1.12/debian-syslog/Dockerfile)
-- `v1.12.0-debian-forward-1.0,v1.12-debian-forward-1` [docker-image/v1.12/debian-forward/Dockerfile](docker-image/v1.12/debian-forward/Dockerfile)
-- `v1.12.0-debian-gcs-1.0,v1.12-debian-gcs-1` [docker-image/v1.12/debian-gcs/Dockerfile](docker-image/v1.12/debian-gcs/Dockerfile)
-- `v1.12.0-debian-graylog-1.0,v1.12-debian-graylog-1` [docker-image/v1.12/debian-graylog/Dockerfile](docker-image/v1.12/debian-graylog/Dockerfile)
-- `v1.12.0-debian-papertrail-1.0,v1.12-debian-papertrail-1` [docker-image/v1.12/debian-papertrail/Dockerfile](docker-image/v1.12/debian-papertrail/Dockerfile)
-- `v1.12.0-debian-logzio-1.0,v1.12-debian-logzio-1` [docker-image/v1.12/debian-logzio/Dockerfile](docker-image/v1.12/debian-logzio/Dockerfile)
-- `v1.12.0-debian-kafka-1.0,v1.12-debian-kafka-1` [docker-image/v1.12/debian-kafka/Dockerfile](docker-image/v1.12/debian-kafka/Dockerfile)
-- `v1.12.0-debian-kafka2-1.0,v1.12-debian-kafka2-1` [docker-image/v1.12/debian-kafka2/Dockerfile](docker-image/v1.12/debian-kafka2/Dockerfile)
-- `v1.12.0-debian-kinesis-1.0,v1.12-debian-kinesis-1` [docker-image/v1.12/debian-kinesis/Dockerfile](docker-image/v1.12/debian-kinesis/Dockerfile)
+- `Azureblob` [Dockerfile](docker-image/v1.12/debian-azureblob/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-azureblob-1.1`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-azureblob-1`
+- `Elasticsearch7` [Dockerfile](docker-image/v1.12/debian-elasticsearch7/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-elasticsearch7-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch7-1`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch`
+- `Elasticsearch6` [Dockerfile](docker-image/v1.12/debian-elasticsearch6/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-elasticsearch6-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch6-1`
+- `Loggly` [Dockerfile](docker-image/v1.12/debian-loggly/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-loggly-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-loggly-1`
+- `Logentries` [Dockerfile](docker-image/v1.12/debian-logentries/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-logentries-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logentries-1`
+- `Cloudwatch` [Dockerfile](docker-image/v1.12/debian-cloudwatch/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-cloudwatch-1.2`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-cloudwatch-1`
+- `Stackdriver` [Dockerfile](docker-image/v1.12/debian-stackdriver/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-stackdriver-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-stackdriver-1`
+- `S3` [Dockerfile](docker-image/v1.12/debian-s3/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-s3-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-s3-1`
+- `Syslog` [Dockerfile](docker-image/v1.12/debian-syslog/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-syslog-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-syslog-1`
+- `Forward` [Dockerfile](docker-image/v1.12/debian-forward/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-forward-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-forward-1`
+- `Gcs` [Dockerfile](docker-image/v1.12/debian-gcs/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-gcs-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-gcs-1`
+- `Graylog` [Dockerfile](docker-image/v1.12/debian-graylog/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-graylog-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-graylog-1`
+- `Papertrail` [Dockerfile](docker-image/v1.12/debian-papertrail/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-papertrail-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-papertrail-1`
+- `Logzio` [Dockerfile](docker-image/v1.12/debian-logzio/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-logzio-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logzio-1`
+- `Kafka` [Dockerfile](docker-image/v1.12/debian-kafka/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-kafka-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka-1`
+- `Kafka2` [Dockerfile](docker-image/v1.12/debian-kafka2/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-kafka2-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka2-1`
+- `Kinesis` [Dockerfile](docker-image/v1.12/debian-kinesis/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-kinesis-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kinesis-1`
 
 ##### arm64 images
-- `v1.12.0-debian-azureblob-arm64-1.1,v1.12-debian-azureblob-arm64-1` [docker-image/v1.12/arm64/debian-azureblob/Dockerfile](docker-image/v1.12/arm64/debian-azureblob/Dockerfile)
-- `v1.12.0-debian-elasticsearch7-arm64-1.0,v1.12-debian-elasticsearch7-arm64-1,v1-debian-elasticsearch-arm64` [docker-image/v1.12/arm64/debian-elasticsearch7/Dockerfile](docker-image/v1.12/arm64/debian-elasticsearch7/Dockerfile)
-- `v1.12.0-debian-elasticsearch6-arm64-1.0,v1.12-debian-elasticsearch6-arm64-1` [docker-image/v1.12/arm64/debian-elasticsearch6/Dockerfile](docker-image/v1.12/arm64/debian-elasticsearch6/Dockerfile)
-- `v1.12.0-debian-loggly-arm64-1.0,v1.12-debian-loggly-arm64-1` [docker-image/v1.12/arm64/debian-loggly/Dockerfile](docker-image/v1.12/arm64/debian-loggly/Dockerfile)
-- `v1.12.0-debian-logentries-arm64-1.0,v1.12-debian-logentries-arm64-1` [docker-image/v1.12/arm64/debian-logentries/Dockerfile](docker-image/v1.12/arm64/debian-logentries/Dockerfile)
-- `v1.12.0-debian-cloudwatch-arm64-1.2,v1.12-debian-cloudwatch-arm64-1` [docker-image/v1.12/arm64/debian-cloudwatch/Dockerfile](docker-image/v1.12/arm64/debian-cloudwatch/Dockerfile)
-- `v1.12.0-debian-stackdriver-arm64-1.0,v1.12-debian-stackdriver-arm64-1` [docker-image/v1.12/arm64/debian-stackdriver/Dockerfile](docker-image/v1.12/arm64/debian-stackdriver/Dockerfile)
-- `v1.12.0-debian-s3-arm64-1.0,v1.12-debian-s3-arm64-1` [docker-image/v1.12/arm64/debian-s3/Dockerfile](docker-image/v1.12/arm64/debian-s3/Dockerfile)
-- `v1.12.0-debian-syslog-arm64-1.0,v1.12-debian-syslog-arm64-1` [docker-image/v1.12/arm64/debian-syslog/Dockerfile](docker-image/v1.12/arm64/debian-syslog/Dockerfile)
-- `v1.12.0-debian-forward-arm64-1.0,v1.12-debian-forward-arm64-1` [docker-image/v1.12/arm64/debian-forward/Dockerfile](docker-image/v1.12/arm64/debian-forward/Dockerfile)
-- `v1.12.0-debian-gcs-arm64-1.0,v1.12-debian-gcs-arm64-1` [docker-image/v1.12/arm64/debian-gcs/Dockerfile](docker-image/v1.12/arm64/debian-gcs/Dockerfile)
-- `v1.12.0-debian-graylog-arm64-1.0,v1.12-debian-graylog-arm64-1` [docker-image/v1.12/arm64/debian-graylog/Dockerfile](docker-image/v1.12/arm64/debian-graylog/Dockerfile)
-- `v1.12.0-debian-papertrail-arm64-1.0,v1.12-debian-papertrail-arm64-1` [docker-image/v1.12/arm64/debian-papertrail/Dockerfile](docker-image/v1.12/arm64/debian-papertrail/Dockerfile)
-- `v1.12.0-debian-logzio-arm64-1.0,v1.12-debian-logzio-arm64-1` [docker-image/v1.12/arm64/debian-logzio/Dockerfile](docker-image/v1.12/arm64/debian-logzio/Dockerfile)
-- `v1.12.0-debian-kafka-arm64-1.0,v1.12-debian-kafka-arm64-1` [docker-image/v1.12/arm64/debian-kafka/Dockerfile](docker-image/v1.12/arm64/debian-kafka/Dockerfile)
-- `v1.12.0-debian-kafka2-arm64-1.0,v1.12-debian-kafka2-arm64-1` [docker-image/v1.12/arm64/debian-kafka2/Dockerfile](docker-image/v1.12/arm64/debian-kafka2/Dockerfile)
-- `v1.12.0-debian-kinesis-arm64-1.0,v1.12-debian-kinesis-arm64-1` [docker-image/v1.12/arm64/debian-kinesis/Dockerfile](docker-image/v1.12/arm64/debian-kinesis/Dockerfile)
+- `Azureblob` [Dockerfile](docker-image/v1.12/arm64/debian-azureblob/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-azureblob-arm64-1.1`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-azureblob-arm64-1`
+- `Elasticsearch7` [Dockerfile](docker-image/v1.12/arm64/debian-elasticsearch7/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-elasticsearch7-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch7-arm64-1`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch-arm64`
+- `Elasticsearch6` [Dockerfile](docker-image/v1.12/arm64/debian-elasticsearch6/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-elasticsearch6-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch6-arm64-1`
+- `Loggly` [Dockerfile](docker-image/v1.12/arm64/debian-loggly/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-loggly-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-loggly-arm64-1`
+- `Logentries` [Dockerfile](docker-image/v1.12/arm64/debian-logentries/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-logentries-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logentries-arm64-1`
+- `Cloudwatch` [Dockerfile](docker-image/v1.12/arm64/debian-cloudwatch/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-cloudwatch-arm64-1.2`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-cloudwatch-arm64-1`
+- `Stackdriver` [Dockerfile](docker-image/v1.12/arm64/debian-stackdriver/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-stackdriver-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-stackdriver-arm64-1`
+- `S3` [Dockerfile](docker-image/v1.12/arm64/debian-s3/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-s3-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-s3-arm64-1`
+- `Syslog` [Dockerfile](docker-image/v1.12/arm64/debian-syslog/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-syslog-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-syslog-arm64-1`
+- `Forward` [Dockerfile](docker-image/v1.12/arm64/debian-forward/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-forward-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-forward-arm64-1`
+- `Gcs` [Dockerfile](docker-image/v1.12/arm64/debian-gcs/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-gcs-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-gcs-arm64-1`
+- `Graylog` [Dockerfile](docker-image/v1.12/arm64/debian-graylog/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-graylog-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-graylog-arm64-1`
+- `Papertrail` [Dockerfile](docker-image/v1.12/arm64/debian-papertrail/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-papertrail-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-papertrail-arm64-1`
+- `Logzio` [Dockerfile](docker-image/v1.12/arm64/debian-logzio/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-logzio-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logzio-arm64-1`
+- `Kafka` [Dockerfile](docker-image/v1.12/arm64/debian-kafka/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-kafka-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka-arm64-1`
+- `Kafka2` [Dockerfile](docker-image/v1.12/arm64/debian-kafka2/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-kafka2-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka2-arm64-1`
+- `Kinesis` [Dockerfile](docker-image/v1.12/arm64/debian-kinesis/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-kinesis-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kinesis-arm64-1`
 
 
 You can also use `v1-debian-PLUGIN` tag to refer latest v1 image, e.g. `v1-debian-elasticsearch`. On production, strict tag is better to avoid unexpected update.

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -20,13 +20,19 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 ##### x86_64 images
 <% debian.each do |image| %>
 <% path = image.split(":").first; tags = image.split(":").last %>
-- `<%= tags %>` [docker-image/<%= path %>/Dockerfile](docker-image/<%= path %>/Dockerfile)
+- `<%= tags.split(",").first.split("-")[2].capitalize %>` [Dockerfile](docker-image/<%= path %>/Dockerfile)
+<% tags.split(",").each do |tag| %>
+  - `docker pull fluent/fluentd-kubernetes-daemonset:<%= tag %>`
+<% end %>
 <% end %>
 
 ##### arm64 images
 <% debian_arm64.each do |image| %>
 <% path = image.split(":").first; tags = image.split(":").last %>
-- `<%= tags %>` [docker-image/<%= path %>/Dockerfile](docker-image/<%= path %>/Dockerfile)
+- `<%= tags.split(",").first.split("-")[2].capitalize %>` [Dockerfile](docker-image/<%= path %>/Dockerfile)
+<% tags.split(",").each do |tag| %>
+  - `docker pull fluent/fluentd-kubernetes-daemonset:<%= tag %>`
+<% end %>
 <% end %>
 
 


### PR DESCRIPTION
Before:

```
- `v1.12.0-debian-azureblob-1.1,v1.12-debian-azureblob-1` [docker-image/v1.12/debian-azureblob/Dockerfile](docker-image/v1.12/debian-azureblob/Dockerfile)
```

After:

```
- `Azureblob` [Dockerfile](docker-image/v1.12/debian-azureblob/Dockerfile)
  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.0-debian-azureblob-1.1`
  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-azureblob-1`
```

Thus, it makes easy to pull image (copy&past)