### PR TITLE
Copy tail_container_parse.conf into Docker Images

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -54,6 +54,7 @@ COPY ./conf/fluent.conf /fluentd/etc/
 COPY ./conf/systemd.conf /fluentd/etc/
 COPY ./conf/kubernetes.conf /fluentd/etc/
 COPY ./conf/prometheus.conf /fluentd/etc/
+COPY ./conf/tail_container_parse.conf /fluentd/etc/
 RUN touch /fluentd/etc/disable.conf
 
 # Copy plugins


### PR DESCRIPTION
Looking at the current Docker images built after https://github.com/fluent/fluentd-kubernetes-daemonset/pull/521 it looks like `tail_container_parse.conf` is not being copied over.

Fixes: https://github.com/fluent/fluentd-kubernetes-daemonset/issues/541