### PR TITLE
change varlibdockercontainer path

### DIFF
--- a/fluentd-daemonset-azureblob.yaml
+++ b/fluentd-daemonset-azureblob.yaml
@@ -104,4 +104,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-cloudwatch-rbac.yaml
+++ b/fluentd-daemonset-cloudwatch-rbac.yaml
@@ -89,4 +89,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-elasticsearch-rbac.yaml
+++ b/fluentd-daemonset-elasticsearch-rbac.yaml
@@ -103,4 +103,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -69,4 +69,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-forward.yaml
+++ b/fluentd-daemonset-forward.yaml
@@ -47,4 +47,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-gcs.yaml
+++ b/fluentd-daemonset-gcs.yaml
@@ -43,4 +43,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-graylog-rbac.yaml
+++ b/fluentd-daemonset-graylog-rbac.yaml
@@ -100,4 +100,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-logentries.yaml
+++ b/fluentd-daemonset-logentries.yaml
@@ -54,4 +54,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-loggly-rbac.yaml
+++ b/fluentd-daemonset-loggly-rbac.yaml
@@ -94,4 +94,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-loggly.yaml
+++ b/fluentd-daemonset-loggly.yaml
@@ -53,4 +53,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods

--- a/fluentd-daemonset-papertrail.yaml
+++ b/fluentd-daemonset-papertrail.yaml
@@ -54,7 +54,7 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods
 #---
 #apiVersion: v1
 #kind: ConfigMap

--- a/fluentd-daemonset-syslog.yaml
+++ b/fluentd-daemonset-syslog.yaml
@@ -92,4 +92,4 @@ spec:
           path: /var/log
       - name: varlibdockercontainers
         hostPath:
-          path: /var/lib/docker/containers
+          path: /var/log/pods


### PR DESCRIPTION
In kubernetes 1.19+ the folder /var/lib/docker/ no more exist and the docker logs are placed in folder /var/logs/pods. 
This happen from the remove of dockershim and moby project layer

No changes on volumeMounts to avoid to edit all configs files

Tested on Azure Kubernetes Service 1.19.7 and 1.20.*

