### PR TITLE
unify multi-arch tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,23 +12,23 @@
 
 IMAGE_NAME := fluent/fluentd-kubernetes
 X86_IMAGES := \
-	v1.12/debian-azureblob:v1.12.4-debian-azureblob-1.0,v1.12-debian-azureblob-1 \
-	v1.12/debian-elasticsearch7:v1.12.4-debian-elasticsearch7-1.0,v1.12-debian-elasticsearch7-1,v1-debian-elasticsearch \
-	v1.12/debian-elasticsearch6:v1.12.4-debian-elasticsearch6-1.0,v1.12-debian-elasticsearch6-1 \
-	v1.12/debian-loggly:v1.12.4-debian-loggly-1.0,v1.12-debian-loggly-1 \
-	v1.12/debian-logentries:v1.12.4-debian-logentries-1.0,v1.12-debian-logentries-1 \
-	v1.12/debian-cloudwatch:v1.12.4-debian-cloudwatch-1.3,v1.12-debian-cloudwatch-1 \
-	v1.12/debian-stackdriver:v1.12.4-debian-stackdriver-1.0,v1.12-debian-stackdriver-1 \
-	v1.12/debian-s3:v1.12.4-debian-s3-1.0,v1.12-debian-s3-1 \
-	v1.12/debian-syslog:v1.12.4-debian-syslog-1.0,v1.12-debian-syslog-1 \
-	v1.12/debian-forward:v1.12.4-debian-forward-1.0,v1.12-debian-forward-1 \
-	v1.12/debian-gcs:v1.12.4-debian-gcs-1.0,v1.12-debian-gcs-1 \
-	v1.12/debian-graylog:v1.12.4-debian-graylog-1.0,v1.12-debian-graylog-1 \
-	v1.12/debian-papertrail:v1.12.4-debian-papertrail-1.0,v1.12-debian-papertrail-1 \
-	v1.12/debian-logzio:v1.12.4-debian-logzio-1.0,v1.12-debian-logzio-1 \
-	v1.12/debian-kafka:v1.12.4-debian-kafka-1.0,v1.12-debian-kafka-1 \
-	v1.12/debian-kafka2:v1.12.4-debian-kafka2-1.0,v1.12-debian-kafka2-1 \
-	v1.12/debian-kinesis:v1.12.4-debian-kinesis-1.1,v1.12-debian-kinesis-1
+	v1.12/debian-azureblob:v1.12.4-debian-azureblob-amd64-1.0,v1.12-debian-azureblob-amd64-1 \
+	v1.12/debian-elasticsearch7:v1.12.4-debian-elasticsearch7-amd64-1.0,v1.12-debian-elasticsearch7-amd64-1,v1-debian-elasticsearch-amd64 \
+	v1.12/debian-elasticsearch6:v1.12.4-debian-elasticsearch6-amd64-1.0,v1.12-debian-elasticsearch6-amd64-1 \
+	v1.12/debian-loggly:v1.12.4-debian-loggly-amd64-1.0,v1.12-debian-loggly-amd64-1 \
+	v1.12/debian-logentries:v1.12.4-debian-logentries-amd64-1.0,v1.12-debian-logentries-amd64-1 \
+	v1.12/debian-cloudwatch:v1.12.4-debian-cloudwatch-amd64-1.3,v1.12-debian-cloudwatch-amd64-1 \
+	v1.12/debian-stackdriver:v1.12.4-debian-stackdriver-amd64-1.0,v1.12-debian-stackdriver-amd64-1 \
+	v1.12/debian-s3:v1.12.4-debian-s3-amd64-1.0,v1.12-debian-s3-amd64-1 \
+	v1.12/debian-syslog:v1.12.4-debian-syslog-amd64-1.0,v1.12-debian-syslog-amd64-1 \
+	v1.12/debian-forward:v1.12.4-debian-forward-amd64-1.0,v1.12-debian-forward-amd64-1 \
+	v1.12/debian-gcs:v1.12.4-debian-gcs-amd64-1.0,v1.12-debian-gcs-amd64-1 \
+	v1.12/debian-graylog:v1.12.4-debian-graylog-amd64-1.0,v1.12-debian-graylog-amd64-1 \
+	v1.12/debian-papertrail:v1.12.4-debian-papertrail-amd64-1.0,v1.12-debian-papertrail-amd64-1 \
+	v1.12/debian-logzio:v1.12.4-debian-logzio-amd64-1.0,v1.12-debian-logzio-amd64-1 \
+	v1.12/debian-kafka:v1.12.4-debian-kafka-amd64-1.0,v1.12-debian-kafka-amd64-1 \
+	v1.12/debian-kafka2:v1.12.4-debian-kafka2-amd64-1.0,v1.12-debian-kafka2-amd64-1 \
+	v1.12/debian-kinesis:v1.12.4-debian-kinesis-amd64-1.1,v1.12-debian-kinesis-amd64-1
 
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 

--- a/README.md
+++ b/README.md
@@ -13,59 +13,113 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 
 #### Current stable
 
-##### x86_64 images
-- `Azureblob` [Dockerfile](docker-image/v1.12/debian-azureblob/Dockerfile)
+##### Multi-Arch images
+- `Azureblob`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-azureblob-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-azureblob-1`
-- `Elasticsearch7` [Dockerfile](docker-image/v1.12/debian-elasticsearch7/Dockerfile)
+- `Elasticsearch7`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-elasticsearch7-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch7-1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch`
-- `Elasticsearch6` [Dockerfile](docker-image/v1.12/debian-elasticsearch6/Dockerfile)
+- `Elasticsearch6`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-elasticsearch6-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch6-1`
-- `Loggly` [Dockerfile](docker-image/v1.12/debian-loggly/Dockerfile)
+- `Loggly`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-loggly-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-loggly-1`
-- `Logentries` [Dockerfile](docker-image/v1.12/debian-logentries/Dockerfile)
+- `Logentries`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-logentries-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logentries-1`
-- `Cloudwatch` [Dockerfile](docker-image/v1.12/debian-cloudwatch/Dockerfile)
+- `Cloudwatch`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-cloudwatch-1.3`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-cloudwatch-1`
-- `Stackdriver` [Dockerfile](docker-image/v1.12/debian-stackdriver/Dockerfile)
+- `Stackdriver`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-stackdriver-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-stackdriver-1`
-- `S3` [Dockerfile](docker-image/v1.12/debian-s3/Dockerfile)
+- `S3`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-s3-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-s3-1`
-- `Syslog` [Dockerfile](docker-image/v1.12/debian-syslog/Dockerfile)
+- `Syslog`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-syslog-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-syslog-1`
-- `Forward` [Dockerfile](docker-image/v1.12/debian-forward/Dockerfile)
+- `Forward`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-forward-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-forward-1`
-- `Gcs` [Dockerfile](docker-image/v1.12/debian-gcs/Dockerfile)
+- `Gcs`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-gcs-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-gcs-1`
-- `Graylog` [Dockerfile](docker-image/v1.12/debian-graylog/Dockerfile)
+- `Graylog`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-graylog-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-graylog-1`
-- `Papertrail` [Dockerfile](docker-image/v1.12/debian-papertrail/Dockerfile)
+- `Papertrail`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-papertrail-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-papertrail-1`
-- `Logzio` [Dockerfile](docker-image/v1.12/debian-logzio/Dockerfile)
+- `Logzio`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-logzio-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logzio-1`
-- `Kafka` [Dockerfile](docker-image/v1.12/debian-kafka/Dockerfile)
+- `Kafka`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-kafka-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka-1`
-- `Kafka2` [Dockerfile](docker-image/v1.12/debian-kafka2/Dockerfile)
+- `Kafka2`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-kafka2-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka2-1`
-- `Kinesis` [Dockerfile](docker-image/v1.12/debian-kinesis/Dockerfile)
+- `Kinesis`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-kinesis-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kinesis-1`
+
+##### x86_64 images
+- `Azureblob` [Dockerfile](docker-image/v1.12/debian-azureblob/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-azureblob-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-azureblob-amd64-1`
+- `Elasticsearch7` [Dockerfile](docker-image/v1.12/debian-elasticsearch7/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-elasticsearch7-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch7-amd64-1`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch`
+- `Elasticsearch6` [Dockerfile](docker-image/v1.12/debian-elasticsearch6/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-elasticsearch6-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-elasticsearch6-amd64-1`
+- `Loggly` [Dockerfile](docker-image/v1.12/debian-loggly/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-loggly-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-loggly-amd64-1`
+- `Logentries` [Dockerfile](docker-image/v1.12/debian-logentries/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-logentries-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logentries-amd64-1`
+- `Cloudwatch` [Dockerfile](docker-image/v1.12/debian-cloudwatch/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-cloudwatch-amd64-1.3`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-cloudwatch-amd64-1`
+- `Stackdriver` [Dockerfile](docker-image/v1.12/debian-stackdriver/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-stackdriver-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-stackdriver-amd64-1`
+- `S3` [Dockerfile](docker-image/v1.12/debian-s3/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-s3-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-s3-amd64-1`
+- `Syslog` [Dockerfile](docker-image/v1.12/debian-syslog/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-syslog-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-syslog-amd64-1`
+- `Forward` [Dockerfile](docker-image/v1.12/debian-forward/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-forward-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-forward-amd64-1`
+- `Gcs` [Dockerfile](docker-image/v1.12/debian-gcs/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-gcs-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-gcs-amd64-1`
+- `Graylog` [Dockerfile](docker-image/v1.12/debian-graylog/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-graylog-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-graylog-amd64-1`
+- `Papertrail` [Dockerfile](docker-image/v1.12/debian-papertrail/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-papertrail-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-papertrail-amd64-1`
+- `Logzio` [Dockerfile](docker-image/v1.12/debian-logzio/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-logzio-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-logzio-amd64-1`
+- `Kafka` [Dockerfile](docker-image/v1.12/debian-kafka/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-kafka-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka-amd64-1`
+- `Kafka2` [Dockerfile](docker-image/v1.12/debian-kafka2/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-kafka2-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kafka2-amd64-1`
+- `Kinesis` [Dockerfile](docker-image/v1.12/debian-kinesis/Dockerfile)
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12.4-debian-kinesis-amd64-1.1`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.12-debian-kinesis-amd64-1`
 
 ##### arm64 images
 - `Azureblob` [Dockerfile](docker-image/v1.12/arm64/debian-azureblob/Dockerfile)

--- a/docker-image/v1.12/arm64/debian-azureblob/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-azureblob/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-azureblob-arm64-1.0,v1.12-debian-azureblob-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-cloudwatch/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-cloudwatch/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-cloudwatch-arm64-1.0,v1.12-debian-cloudwatch-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-elasticsearch6/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-elasticsearch6/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-elasticsearch6-arm64-1.0,v1.12-debian-elasticsearch6-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-elasticsearch7/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-elasticsearch7/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-elasticsearch7-arm64-1.0,v1.12-debian-elasticsearch7-arm64-1,v1-debian-elasticsearch-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-forward/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-forward/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-forward-arm64-1.0,v1.12-debian-forward-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-gcs/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-gcs/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-gcs-arm64-1.0,v1.12-debian-gcs-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-graylog/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-graylog/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-graylog-arm64-1.0,v1.12-debian-graylog-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-kafka/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-kafka/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-kafka-arm64-1.0,v1.12-debian-kafka-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-kafka2/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-kafka2/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-kafka2-arm64-1.0,v1.12-debian-kafka2-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-kinesis/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-kinesis/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-kinesis-arm64-1.1,v1.12-debian-kinesis-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-logentries/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-logentries/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-logentries-arm64-1.0,v1.12-debian-logentries-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-loggly/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-loggly/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-loggly-arm64-1.0,v1.12-debian-loggly-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-logzio/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-logzio/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-logzio-arm64-1.0,v1.12-debian-logzio-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-papertrail/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-papertrail/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-papertrail-arm64-1.0,v1.12-debian-papertrail-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-s3/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-s3/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-s3-arm64-1.0,v1.12-debian-s3-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-stackdriver/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-stackdriver/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-stackdriver-arm64-1.0,v1.12-debian-stackdriver-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/arm64/debian-syslog/hooks/post_push
+++ b/docker-image/v1.12/arm64/debian-syslog/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {v1.12.4-debian-syslog-arm64-1.0,v1.12-debian-syslog-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-azureblob/hooks/post_push
+++ b/docker-image/v1.12/debian-azureblob/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-azureblob-1.0,v1.12-debian-azureblob-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-azureblob-amd64-1.0,v1.12-debian-azureblob-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-cloudwatch/hooks/post_push
+++ b/docker-image/v1.12/debian-cloudwatch/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-cloudwatch-1.3,v1.12-debian-cloudwatch-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-cloudwatch-amd64-1.3,v1.12-debian-cloudwatch-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-elasticsearch6/hooks/post_push
+++ b/docker-image/v1.12/debian-elasticsearch6/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-elasticsearch6-1.0,v1.12-debian-elasticsearch6-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-elasticsearch6-amd64-1.0,v1.12-debian-elasticsearch6-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-elasticsearch7/hooks/post_push
+++ b/docker-image/v1.12/debian-elasticsearch7/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-elasticsearch7-1.0,v1.12-debian-elasticsearch7-1,v1-debian-elasticsearch}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-elasticsearch7-amd64-1.0,v1.12-debian-elasticsearch7-amd64-1,v1-debian-elasticsearch-amd64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-forward/hooks/post_push
+++ b/docker-image/v1.12/debian-forward/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-forward-1.0,v1.12-debian-forward-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-forward-amd64-1.0,v1.12-debian-forward-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-gcs/hooks/post_push
+++ b/docker-image/v1.12/debian-gcs/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-gcs-1.0,v1.12-debian-gcs-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-gcs-amd64-1.0,v1.12-debian-gcs-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-graylog/hooks/post_push
+++ b/docker-image/v1.12/debian-graylog/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-graylog-1.0,v1.12-debian-graylog-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-graylog-amd64-1.0,v1.12-debian-graylog-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-kafka/hooks/post_push
+++ b/docker-image/v1.12/debian-kafka/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-kafka-1.0,v1.12-debian-kafka-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-kafka-amd64-1.0,v1.12-debian-kafka-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-kafka2/hooks/post_push
+++ b/docker-image/v1.12/debian-kafka2/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-kafka2-1.0,v1.12-debian-kafka2-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-kafka2-amd64-1.0,v1.12-debian-kafka2-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-kinesis/hooks/post_push
+++ b/docker-image/v1.12/debian-kinesis/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-kinesis-1.1,v1.12-debian-kinesis-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-kinesis-amd64-1.1,v1.12-debian-kinesis-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-logentries/hooks/post_push
+++ b/docker-image/v1.12/debian-logentries/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-logentries-1.0,v1.12-debian-logentries-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-logentries-amd64-1.0,v1.12-debian-logentries-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-loggly/hooks/post_push
+++ b/docker-image/v1.12/debian-loggly/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-loggly-1.0,v1.12-debian-loggly-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-loggly-amd64-1.0,v1.12-debian-loggly-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-logzio/hooks/post_push
+++ b/docker-image/v1.12/debian-logzio/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-logzio-1.0,v1.12-debian-logzio-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-logzio-amd64-1.0,v1.12-debian-logzio-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-papertrail/hooks/post_push
+++ b/docker-image/v1.12/debian-papertrail/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-papertrail-1.0,v1.12-debian-papertrail-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-papertrail-amd64-1.0,v1.12-debian-papertrail-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-s3/hooks/post_push
+++ b/docker-image/v1.12/debian-s3/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-s3-1.0,v1.12-debian-s3-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-s3-amd64-1.0,v1.12-debian-s3-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-stackdriver/hooks/post_push
+++ b/docker-image/v1.12/debian-stackdriver/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-stackdriver-1.0,v1.12-debian-stackdriver-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-stackdriver-amd64-1.0,v1.12-debian-stackdriver-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/docker-image/v1.12/debian-syslog/hooks/post_push
+++ b/docker-image/v1.12/debian-syslog/hooks/post_push
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
-for tag in {v1.12.4-debian-syslog-1.0,v1.12-debian-syslog-1}; do
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
+for tag in {v1.12.4-debian-syslog-amd64-1.0,v1.12-debian-syslog-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -17,6 +17,15 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 
 #### Current stable
 
+##### Multi-Arch images
+<% debian.each do |image| %>
+<% path = image.split(":").first.sub("-amd64",""); tags = image.split(":").last %>
+- `<%= tags.split(",").first.split("-")[2].capitalize %>`
+<% tags.split(",").each do |tag| %>
+  - `docker pull fluent/fluentd-kubernetes-daemonset:<%= tag.sub("-amd64","") %>`
+<% end %>
+<% end %>
+
 ##### x86_64 images
 <% debian.each do |image| %>
 <% path = image.split(":").first; tags = image.split(":").last %>

--- a/templates/post_push.erb
+++ b/templates/post_push.erb
@@ -8,8 +8,17 @@ set -e
 tagStart=$(expr index "$IMAGE_NAME" :)
 repoName=${IMAGE_NAME:0:tagStart-1}
 
-# Tag and push image for each additional tag
+# Download manifest tool
+curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download/v1.0.3/manifest-tool-linux-amd64
+chmod +x manifest-tool
+
+# Tag and push image and manifest list for each additional tag
 for tag in {<%= image_tags %>}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
+  # Note: this will fail until both the amd64 and arm64 images have been pushed
+  ./manifest-tool push from-args \
+      --platforms linux/amd64,linux/arm64 \
+      --template ${repoName}:${tag/amd64|arm64/ARCH} \
+      --target ${repoName}:${tag/-amd64|-arm64/}
 done


### PR DESCRIPTION
This PR extends the automated DockerHub builds to produce a multi-arch image / manifest list in addition to the base per-architecture images by using [manifest-tool](https://github.com/estesp/manifest-tool) (based on [this example](https://github.com/ckulka/docker-multi-arch-example)) to create the manifest list instead of `docker manifest`, which is still unsupported in DockerHub builds.

These changes should be compatible with the existing DockerHub build settings, but note that both the amd64 and arm64 images must be available on DockerHub in order for `manifest-tool` to create the manifest list, so only the last architecture-specific build will be marked as `Successful` in the [build history](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset/builds).

Fixes #524.