### PR TITLE
Update kubernetes_metadata_filter to v2.7.1

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -62,7 +62,7 @@ gem "fluent-plugin-kinesis", "~> 3.4.0"
 <% when "splunkhec" %>
 gem "fluent-plugin-splunk-enterprise"
 <% end %>
-gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.6.0"
+gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.7.1"
 <% if !is_alpine %>
 gem "ffi"
 gem "fluent-plugin-systemd", "~> 1.0.2"


### PR DESCRIPTION
Fluentd v1.13.0 or later is supported since v2.7.1
