### PR TITLE
Configure dependabot behavior

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  # Watch dependencies for current stable
+  - package-ecosystem: "bundler"
+    directory: "/docker-image"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
It is introduced not to watch deprecated images.

ref. https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
