### PR TITLE
Use fixed memory leak issue of fluent-plugin-systemd

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -65,5 +65,5 @@ gem "fluent-plugin-splunk-enterprise"
 gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.7.1"
 <% if !is_alpine %>
 gem "ffi"
-gem "fluent-plugin-systemd", "~> 1.0.2"
+gem "fluent-plugin-systemd", "~> 1.0.5"
 <% end %>


### PR DESCRIPTION
See
https://github.com/fluent-plugin-systemd/fluent-plugin-systemd/pull/91

TODO: make src-all when it is ready for newer release
