### PR TITLE
dependabot: Try to receive only security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,618 +7,721 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
   # Watch dependencies for current stable only
 
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-loggly"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-gcs"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-forward"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-elasticsearch6"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-loggly"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-gcs"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-forward"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-elasticsearch6"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-logentries"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-kafka2"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-s3"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-syslog"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-azureblob"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-stackdriver"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-papertrail"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-cloudwatch"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-logzio"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-elasticsearch7"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-kinesis"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-graylog"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/arm64/debian-kafka"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-logentries"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-kafka2"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-s3"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-syslog"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-azureblob"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-stackdriver"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-papertrail"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-cloudwatch"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-logzio"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-elasticsearch7"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-kinesis"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-graylog"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.13/debian-kafka"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-loggly"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-gcs"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-forward"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-elasticsearch6"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-loggly"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-gcs"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-forward"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-elasticsearch6"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-logentries"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-kafka2"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-s3"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-syslog"
-    schedule:
-      interval: "daily"
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/arm64/debian-azureblob"
     schedule:
       interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-stackdriver"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-papertrail"
-    schedule:
-      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/arm64/debian-cloudwatch"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-logzio"
+    directory: "/docker-image/v1.11/arm64/debian-elasticsearch6"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/arm64/debian-elasticsearch7"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/arm64/debian-kinesis"
+    directory: "/docker-image/v1.11/arm64/debian-forward"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.11/arm64/debian-gcs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/arm64/debian-graylog"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/arm64/debian-kafka"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-logentries"
+    directory: "/docker-image/v1.11/arm64/debian-kafka2"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-kafka2"
+    directory: "/docker-image/v1.11/arm64/debian-kinesis"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-s3"
+    directory: "/docker-image/v1.11/arm64/debian-logentries"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-syslog"
+    directory: "/docker-image/v1.11/arm64/debian-loggly"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.11/arm64/debian-logzio"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.11/arm64/debian-papertrail"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.11/arm64/debian-s3"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.11/arm64/debian-stackdriver"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.11/arm64/debian-syslog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/debian-azureblob"
     schedule:
       interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-stackdriver"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-papertrail"
-    schedule:
-      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/debian-cloudwatch"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-logzio"
+    directory: "/docker-image/v1.11/debian-elasticsearch6"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/debian-elasticsearch7"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.11/debian-kinesis"
+    directory: "/docker-image/v1.11/debian-forward"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.11/debian-gcs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/debian-graylog"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.11/debian-kafka"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-loggly"
+    directory: "/docker-image/v1.11/debian-kafka2"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-gcs"
+    directory: "/docker-image/v1.11/debian-kinesis"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-forward"
+    directory: "/docker-image/v1.11/debian-logentries"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-elasticsearch6"
+    directory: "/docker-image/v1.11/debian-loggly"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-loggly"
+    directory: "/docker-image/v1.11/debian-logzio"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-gcs"
+    directory: "/docker-image/v1.11/debian-papertrail"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-forward"
+    directory: "/docker-image/v1.11/debian-s3"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-elasticsearch6"
+    directory: "/docker-image/v1.11/debian-stackdriver"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-logentries"
+    directory: "/docker-image/v1.11/debian-syslog"
     schedule:
       interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-kafka2"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-s3"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-syslog"
-    schedule:
-      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/arm64/debian-azureblob"
     schedule:
       interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-stackdriver"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-papertrail"
-    schedule:
-      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/arm64/debian-cloudwatch"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-logzio"
+    directory: "/docker-image/v1.12/arm64/debian-elasticsearch6"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/arm64/debian-elasticsearch7"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/arm64/debian-kinesis"
+    directory: "/docker-image/v1.12/arm64/debian-forward"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/arm64/debian-gcs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/arm64/debian-graylog"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/arm64/debian-kafka"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-logentries"
+    directory: "/docker-image/v1.12/arm64/debian-kafka2"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-kafka2"
+    directory: "/docker-image/v1.12/arm64/debian-kinesis"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-s3"
+    directory: "/docker-image/v1.12/arm64/debian-logentries"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-syslog"
+    directory: "/docker-image/v1.12/arm64/debian-loggly"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/arm64/debian-logzio"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/arm64/debian-papertrail"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/arm64/debian-s3"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/arm64/debian-stackdriver"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/arm64/debian-syslog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/debian-azureblob"
     schedule:
       interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-stackdriver"
-    schedule:
-      interval: "daily"
-
-
-  - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-papertrail"
-    schedule:
-      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/debian-cloudwatch"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-logzio"
+    directory: "/docker-image/v1.12/debian-elasticsearch6"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/debian-elasticsearch7"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
-    directory: "/docker-image/v1.12/debian-kinesis"
+    directory: "/docker-image/v1.12/debian-forward"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-gcs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/debian-graylog"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 
 
   - package-ecosystem: "bundler"
     directory: "/docker-image/v1.12/debian-kafka"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-kafka2"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-kinesis"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-logentries"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-loggly"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-logzio"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-papertrail"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-s3"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-stackdriver"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.12/debian-syslog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-azureblob"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-cloudwatch"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-elasticsearch6"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-elasticsearch7"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-forward"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-gcs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-graylog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-kafka"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-kafka2"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-kinesis"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-logentries"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-loggly"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-logzio"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-papertrail"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-s3"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-stackdriver"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/arm64/debian-syslog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-azureblob"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-cloudwatch"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-elasticsearch6"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-elasticsearch7"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-forward"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-gcs"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-graylog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-kafka"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-kafka2"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-kinesis"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-logentries"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-loggly"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-logzio"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-papertrail"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-s3"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-stackdriver"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
+
+
+  - package-ecosystem: "bundler"
+    directory: "/docker-image/v1.13/debian-syslog"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 0
 

--- a/templates/dependabot.yml.erb
+++ b/templates/dependabot.yml.erb
@@ -7,12 +7,14 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
   # Watch dependencies for current stable only
-<% available_gemfile_paths = Dir.glob("docker-image/**/*/Gemfile") %>
+<% available_gemfile_paths = Dir.glob("docker-image/**/*/Gemfile").sort %>
 <% available_gemfile_paths.each do |gemfile_path| %>
 <% path = File.dirname(gemfile_path) %>
   - package-ecosystem: "bundler"
     directory: "/<%= path %>"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0
 <% end %>


### PR DESCRIPTION
We don't intend to receive all updates, we want only security updates.
For this purpose, `open-pull-requests-limit: 0` seems effective because it doesn't affect to security updates:

https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates#open-pull-requests-limit