### PR TITLE
Update fluentd-daemonset-elasticsearch.yaml

### DIFF
--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -50,6 +50,10 @@ spec:
             value: "ThisIsASuperLongToken"
           - name: LOGZIO_LOGTYPE
             value: "kubernetes"
+          # Prefix for visualization in Kibana(prefix-pattern)
+          # ==================================================
+         - name: FLUENT_ELASTICSEARCH_LOGSTASH_PREFIX
+           value: fluentd
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
In the search index-pattern in kibana, the same is appear with 'logstash' prefix, confusing users.