### PR TITLE
chore: bump GCS plugin to 0.4.1

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -41,7 +41,7 @@ gem "fluent-plugin-azure-storage-append-blob-lts", "~> 0.6.0"
 gem "aws-sdk-s3", "~> 1.91"
 gem "fluent-plugin-s3", "~> 1.6.0"
 <% when "gcs" %>
-gem "fluent-plugin-gcs", "0.4.0"
+gem "fluent-plugin-gcs", "0.4.1"
 <% when "graylog" %>
 gem "gelf", "3.0.0"
 gem "fluent-plugin-gelf-hs", "~> 1.0.7"


### PR DESCRIPTION
This PR update the GCS plugin to the latest version see [CHANGELOG](https://github.com/daichirata/fluent-plugin-gcs/blob/master/CHANGELOG.md#041---20200417).