### PR TITLE
Include tail_container_parse.conf

### DIFF
--- a/templates/conf/kubernetes/containers.conf.erb
+++ b/templates/conf/kubernetes/containers.conf.erb
@@ -6,8 +6,5 @@
   tag "#{ENV['FLUENT_CONTAINER_TAIL_TAG'] || 'kubernetes.*'}"
   exclude_path "#{ENV['FLUENT_CONTAINER_TAIL_EXCLUDE_PATH'] || use_default}"
   read_from_head true
-  <parse>
-    @type "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TYPE'] || 'json'}"
-    time_format "#{ENV['FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT'] || '%Y-%m-%dT%H:%M:%S.%NZ'}"
-  </parse>
+  @include ../tail_container_parse.conf
 </source>


### PR DESCRIPTION
Including tail_container_parse.conf was removed at #585 unexpectedly
and contents of the file is merged into kubernetes/containers.conf.
But the file doesn't exist, the following usage described in README.md
doesn't work as expected.

```
You can use `cri` parser by overwriting `tail_container_parse.conf` via ConfigMap.
```

Signed-off-by: Takuro Ashie <ashie@clear-code.com>