### PR TITLE
Bump fluent-plugin-kubernetes_metadata_filter to 2.9.2

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -62,7 +62,7 @@ gem "fluent-plugin-kinesis", "~> 3.4.0"
 <% when "splunkhec" %>
 gem "fluent-plugin-splunk-enterprise"
 <% end %>
-gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.8.0"
+gem "fluent-plugin-kubernetes_metadata_filter", "~> 2.9.2"
 <% if !is_alpine %>
 gem "ffi"
 gem "fluent-plugin-systemd", "~> 1.0.5"


### PR DESCRIPTION
An important fix was introduced in ` fluent-plugin-kubernetes_metadata_filter` version `2.8.1` which is still unavailable in current docker image. 

In version `2.8.0`, the one in current docker image, kubernetes metadata filter isn't working and throwing following warning:
```
2021-11-10 13:06:39 +0000 [warn]: #0 [filter_kube_metadata] parsing container meta information failed for: namespace/pod: undefined method `sub' for nil:NilClass
```
Updating to latest available version i.e. `2.9.2`
Issue here - https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter/issues/294

Signed-off-by: Aditya Jalkhare <aditya.jalkhare@gmail.com>