### PR TITLE
Cleanup for elasticsearch values

### DIFF
--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -44,12 +44,6 @@ spec:
             value: "elastic"
           - name: FLUENT_ELASTICSEARCH_PASSWORD
             value: "changeme"
-          # Logz.io Authentication
-          # ======================
-          - name: LOGZIO_TOKEN
-            value: "ThisIsASuperLongToken"
-          - name: LOGZIO_LOGTYPE
-            value: "kubernetes"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
To avoid confusion that `logz.io` is needed in order to deploy using `fluentd-daemonset-elasticsearch.yaml`