### PR TITLE
arm64: fix qemu SEGV during build process

### DIFF
--- a/docker-image/v1.14/arm64/debian-azureblob/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-azureblob/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-cloudwatch/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-cloudwatch/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-elasticsearch6/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-elasticsearch6/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-elasticsearch7/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-elasticsearch7/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-forward/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-forward/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-gcs/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-gcs/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-graylog/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-graylog/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-kafka/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-kafka/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-kafka2/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-kafka2/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-kinesis/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-kinesis/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-logentries/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-logentries/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-loggly/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-loggly/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-logzio/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-logzio/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-papertrail/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-papertrail/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-s3/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-s3/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-stackdriver/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-stackdriver/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/docker-image/v1.14/arm64/debian-syslog/Dockerfile
+++ b/docker-image/v1.14/arm64/debian-syslog/Dockerfile
@@ -4,9 +4,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:v1.14.5-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -9,9 +9,9 @@
 # For multiarch build on Docker hub automated build.
 FROM golang:alpine AS builder
 WORKDIR /go
-ENV QEMU_DOWNLOAD_SHA256 a1ef52971537e11915565233f48aa179839f676008d7911c05b3ae94c08c4f5c
+ENV QEMU_DOWNLOAD_SHA256 5db25cccb40ac7b1ca857653b883376b931d91b06ff34ffe70dcf6180bd07bb8
 RUN apk add curl --no-cache
-RUN curl -sL -o qemu-3.0.0+resin-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v3.0.0%2Bresin/qemu-3.0.0+resin-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-3.0.0+resin-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-3.0.0+resin-aarch64.tar.gz -C . && mv qemu-3.0.0+resin-aarch64/qemu-aarch64-static .
+RUN curl -sL -o qemu-6.0.0.balena1-aarch64.tar.gz https://github.com/balena-io/qemu/releases/download/v6.0.0%2Bbalena1/qemu-6.0.0.balena1-aarch64.tar.gz && echo "$QEMU_DOWNLOAD_SHA256 *qemu-6.0.0.balena1-aarch64.tar.gz" | sha256sum -c - | tar zxvf qemu-6.0.0.balena1-aarch64.tar.gz -C . && mv qemu-6.0.0+balena1-aarch64/qemu-aarch64-static .
 
 FROM fluent/fluentd:<%= fluentd_ver %>-debian-arm64-1.0
 COPY --from=builder /go/qemu-aarch64-static /usr/bin/


### PR DESCRIPTION
Followup #1336

Docker hub automated build fails with qemu

It is caused by problematic qemu-user-static which contains a bug that crashes
arm64 Debian derivatives.

  #16 104.7 update-alternatives: using /usr/bin/g++ to provide /usr/bin/c++ (c++) in auto mode
  #16 104.7 Processing triggers for libc-bin (2.31-13+deb11u2) ...
  #16 104.8 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
  #16 105.0 Segmentation fault (core dumped)
  #16 105.0 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
  #16 105.3 Segmentation fault (core dumped)
  #16 105.3 dpkg: error processing package libc-bin (--configure):
  #16 105.3 installed libc-bin package post-installation script subprocess returned error exit status 139
  #16 105.3 Errors were encountered while processing:
  #16 105.3 libc-bin
  #16 105.4 E: Sub-process /usr/bin/dpkg returned an error code (1)

See https://github.com/fluent/fluentd-docker-image/pull/315

