### PR TITLE
Drop Elasticsearch 6 tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,6 @@ If you want to use above non published images, build it by yourself. Dockefile i
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14.5-debian-elasticsearch7-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-elasticsearch7-1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch`
-- `Elasticsearch6`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14.5-debian-elasticsearch6-1.1`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-elasticsearch6-1`
 - `Opensearch`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14.5-debian-opensearch-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-opensearch-1`
@@ -68,8 +65,6 @@ If you want to use above non published images, build it by yourself. Dockefile i
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-elasticsearch7-amd64-1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch-amd64`
 - `Elasticsearch6` [Dockerfile](docker-image/v1.14/debian-elasticsearch6/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14.5-debian-elasticsearch6-amd64-1.1`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-elasticsearch6-amd64-1`
 - `Opensearch` [Dockerfile](docker-image/v1.14/debian-opensearch/Dockerfile)
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14.5-debian-opensearch-amd64-1.0`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-opensearch-amd64-1`
@@ -119,8 +114,6 @@ If you want to use above non published images, build it by yourself. Dockefile i
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-elasticsearch7-arm64-1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch-arm64`
 - `Elasticsearch6` [Dockerfile](docker-image/v1.14/arm64/debian-elasticsearch6/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14.5-debian-elasticsearch6-arm64-1.1`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-elasticsearch6-arm64-1`
 - `Opensearch` [Dockerfile](docker-image/v1.14/arm64/debian-opensearch/Dockerfile)
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14.5-debian-opensearch-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.14-debian-opensearch-arm64-1`

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -15,8 +15,8 @@ See also dockerhub tags page: https://hub.docker.com/r/fluent/fluentd-kubernetes
 <% debian_arm64 = images.select { |i| i.match(/debian-.*-arm64/) } %>
 <% debian = images.select { |i| i.match("debian") }.reject { |i| debian_arm64.include?(i) } %>
 <% alpine = images.select { |i| i.match("alpine") } %>
-<% no_built_x86_64_images = %w(stackdriver papertrail syslog) %>
-<% no_built_arm64_images = %w(stackdriver papertrail syslog logentries loggly logzio s3) %>
+<% no_built_x86_64_images = %w(stackdriver papertrail syslog elasticsearch6) %>
+<% no_built_arm64_images = %w(stackdriver papertrail syslog logentries loggly logzio s3 elasticsearch6) %>
 <% no_built_multiarch_images = no_built_arm64_images.dup.concat(no_built_x86_64_images).uniq %>
 
 ### Debian


### PR DESCRIPTION
Because Elasticsearch 6 is already EOL.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>