### PR TITLE
Feed fluent-kubernetes-metadata-plugin with the node name

### DIFF
--- a/fluentd-daemonset-azureblob.yaml
+++ b/fluentd-daemonset-azureblob.yaml
@@ -64,12 +64,16 @@ spec:
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-azureblob
         imagePullPolicy: Always
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           # See https://github.com/elsesiy/fluent-plugin-azure-storage-append-blob-lts#configuration for all configuration options & combinations
           - name: AZUREBLOB_AZURE_CLOUD
             value: "AZUREPUBLICCLOUD"
           - name:  AZUREBLOB_ACCOUNT_NAME
             value: "mystorageaccount"
-          # Use AZUREBLOB_ACCOUNT_KEY for access key authorization, AZUREBLOB_SAS_TOKEN for shared access signature authorization, 
+          # Use AZUREBLOB_ACCOUNT_KEY for access key authorization, AZUREBLOB_SAS_TOKEN for shared access signature authorization,
           # AZUREBLOB_CONNECTION_STRING to use the full connection string generated in the Azure Portal or neither to use Managed Service Identity.
           - name:  AZUREBLOB_ACCOUNT_KEY
             value: "mystorageaccountkey"

--- a/fluentd-daemonset-cloudwatch-rbac.yaml
+++ b/fluentd-daemonset-cloudwatch-rbac.yaml
@@ -67,6 +67,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-cloudwatch
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: LOG_GROUP_NAME
             value: "k8s"
           - name: AWS_REGION

--- a/fluentd-daemonset-elasticsearch-rbac.yaml
+++ b/fluentd-daemonset-elasticsearch-rbac.yaml
@@ -65,6 +65,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name:  FLUENT_ELASTICSEARCH_HOST
             value: "elasticsearch-logging"
           - name:  FLUENT_ELASTICSEARCH_PORT

--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -26,6 +26,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name:  FLUENT_ELASTICSEARCH_HOST
             value: "elasticsearch-logging"
           - name:  FLUENT_ELASTICSEARCH_PORT

--- a/fluentd-daemonset-forward.yaml
+++ b/fluentd-daemonset-forward.yaml
@@ -26,6 +26,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-forward
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name:  FLUENT_FOWARD_HOST
             value: "REMOTE_ENDPOINT"
           - name:  FLUENT_FOWARD_PORT

--- a/fluentd-daemonset-gcs.yaml
+++ b/fluentd-daemonset-gcs.yaml
@@ -22,6 +22,10 @@ spec:
       - name: fluentd-gcs
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-gcs
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name:  GCS_BUCKET_PROJECT
             value: "myproject"
           - name:  GCS_BUCKET_NAME

--- a/fluentd-daemonset-graylog-rbac.yaml
+++ b/fluentd-daemonset-graylog-rbac.yaml
@@ -71,6 +71,10 @@ spec:
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-graylog
         imagePullPolicy: IfNotPresent
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name:  FLUENT_GRAYLOG_HOST
             value: "graylog-server-ip-or-dns-name"
           - name:  FLUENT_GRAYLOG_PORT

--- a/fluentd-daemonset-logentries.yaml
+++ b/fluentd-daemonset-logentries.yaml
@@ -32,6 +32,11 @@ spec:
       containers:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-logentries
+        env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
         resources:
           limits:
             memory: 200Mi

--- a/fluentd-daemonset-loggly-rbac.yaml
+++ b/fluentd-daemonset-loggly-rbac.yaml
@@ -65,6 +65,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-loggly
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           # See https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v1.4/debian-loggly/conf/fluent.conf
           # loggly_url "https://logs-01.loggly.com/bulk/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}/bulk"
           - name: LOGGLY_TOKEN
@@ -72,9 +76,9 @@ spec:
           - name: LOGGLY_TAGS
             value: exampletag1,exampletag2
           # Depending on your configuration, adapt or remove the FLUENTD_* variables:
-          - name: FLUENTD_SYSTEMD_CONF 
+          - name: FLUENTD_SYSTEMD_CONF
             value: disable
-          - name: FLUENTD_PROMETHEUS_CONF 
+          - name: FLUENTD_PROMETHEUS_CONF
             value: disable
         resources:
           limits:

--- a/fluentd-daemonset-loggly.yaml
+++ b/fluentd-daemonset-loggly.yaml
@@ -25,6 +25,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-loggly
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           # See https://github.com/fluent/fluentd-kubernetes-daemonset/blob/master/docker-image/v1.4/debian-loggly/conf/fluent.conf
           # loggly_url "https://logs-01.loggly.com/bulk/#{ENV['LOGGLY_TOKEN']}/tag/#{ENV['LOGGLY_TAGS'] || 'fluentd'}/bulk"
           - name: LOGGLY_TOKEN
@@ -32,9 +36,9 @@ spec:
           - name: LOGGLY_TAGS
             value: exampletag1,exampletag2
           # Depending on your configuration, adapt or remove the FLUENTD_* variables:
-          - name: FLUENTD_SYSTEMD_CONF 
+          - name: FLUENTD_SYSTEMD_CONF
             value: disable
-          - name: FLUENTD_PROMETHEUS_CONF 
+          - name: FLUENTD_PROMETHEUS_CONF
             value: disable
         resources:
           limits:

--- a/fluentd-daemonset-opensearch.yaml
+++ b/fluentd-daemonset-opensearch.yaml
@@ -26,6 +26,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-opensearch
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name:  FLUENT_OPENSEARCH_HOST
             value: "opensearch-logging"
           - name:  FLUENT_OPENSEARCH_PORT

--- a/fluentd-daemonset-papertrail.yaml
+++ b/fluentd-daemonset-papertrail.yaml
@@ -27,6 +27,10 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-papertrail
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name: FLUENT_PAPERTRAIL_HOST
             value: "logsX.papertrailapp.com"
           - name: FLUENT_PAPERTRAIL_PORT

--- a/fluentd-daemonset-syslog.yaml
+++ b/fluentd-daemonset-syslog.yaml
@@ -68,12 +68,16 @@ spec:
       - name: fluentd
         image: fluent/fluentd-kubernetes-daemonset:v1-debian-syslog
         env:
+          - name: K8S_NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
           - name:  SYSLOG_HOST
             value: "sysloghost"
           - name:  SYSLOG_PORT
             value: "514"
           - name:  SYSLOG_PROTOCOL
-            value: "udp"            
+            value: "udp"
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
This reduces cache misses and needless calls to the Kubernetes API.

https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes