### PR TITLE
Avoid using async v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,46 +12,46 @@
 
 IMAGE_NAME := fluent/fluentd-kubernetes
 X86_IMAGES := \
-	v1.15/debian-azureblob:v1.15.1-debian-azureblob-amd64-1.0,v1.15-debian-azureblob-amd64-1 \
-	v1.15/debian-elasticsearch7:v1.15.1-debian-elasticsearch7-amd64-1.0,v1.15-debian-elasticsearch7-amd64-1,v1-debian-elasticsearch-amd64 \
-	v1.15/debian-elasticsearch6:v1.15.1-debian-elasticsearch6-amd64-1.0,v1.15-debian-elasticsearch6-amd64-1 \
-	v1.15/debian-opensearch:v1.15.1-debian-opensearch-amd64-1.0,v1.15-debian-opensearch-amd64-1 \
-	v1.15/debian-loggly:v1.15.1-debian-loggly-amd64-1.0,v1.15-debian-loggly-amd64-1 \
-	v1.15/debian-logentries:v1.15.1-debian-logentries-amd64-1.0,v1.15-debian-logentries-amd64-1 \
-	v1.15/debian-cloudwatch:v1.15.1-debian-cloudwatch-amd64-1.0,v1.15-debian-cloudwatch-amd64-1 \
-	v1.15/debian-stackdriver:v1.15.1-debian-stackdriver-amd64-1.0,v1.15-debian-stackdriver-amd64-1 \
-	v1.15/debian-s3:v1.15.1-debian-s3-amd64-1.0,v1.15-debian-s3-amd64-1 \
-	v1.15/debian-syslog:v1.15.1-debian-syslog-amd64-1.0,v1.15-debian-syslog-amd64-1 \
-	v1.15/debian-forward:v1.15.1-debian-forward-amd64-1.0,v1.15-debian-forward-amd64-1 \
-	v1.15/debian-gcs:v1.15.1-debian-gcs-amd64-1.0,v1.15-debian-gcs-amd64-1 \
-	v1.15/debian-graylog:v1.15.1-debian-graylog-amd64-1.0,v1.15-debian-graylog-amd64-1 \
-	v1.15/debian-papertrail:v1.15.1-debian-papertrail-amd64-1.0,v1.15-debian-papertrail-amd64-1 \
-	v1.15/debian-logzio:v1.15.1-debian-logzio-amd64-1.0,v1.15-debian-logzio-amd64-1 \
-	v1.15/debian-kafka:v1.15.1-debian-kafka-amd64-1.0,v1.15-debian-kafka-amd64-1 \
-	v1.15/debian-kafka2:v1.15.1-debian-kafka2-amd64-1.0,v1.15-debian-kafka2-amd64-1 \
-	v1.15/debian-kinesis:v1.15.1-debian-kinesis-amd64-1.0,v1.15-debian-kinesis-amd64-1
+	v1.15/debian-azureblob:v1.15.1-debian-azureblob-amd64-1.1,v1.15-debian-azureblob-amd64-1 \
+	v1.15/debian-elasticsearch7:v1.15.1-debian-elasticsearch7-amd64-1.1,v1.15-debian-elasticsearch7-amd64-1,v1-debian-elasticsearch-amd64 \
+	v1.15/debian-elasticsearch6:v1.15.1-debian-elasticsearch6-amd64-1.1,v1.15-debian-elasticsearch6-amd64-1 \
+	v1.15/debian-opensearch:v1.15.1-debian-opensearch-amd64-1.1,v1.15-debian-opensearch-amd64-1 \
+	v1.15/debian-loggly:v1.15.1-debian-loggly-amd64-1.1,v1.15-debian-loggly-amd64-1 \
+	v1.15/debian-logentries:v1.15.1-debian-logentries-amd64-1.1,v1.15-debian-logentries-amd64-1 \
+	v1.15/debian-cloudwatch:v1.15.1-debian-cloudwatch-amd64-1.1,v1.15-debian-cloudwatch-amd64-1 \
+	v1.15/debian-stackdriver:v1.15.1-debian-stackdriver-amd64-1.1,v1.15-debian-stackdriver-amd64-1 \
+	v1.15/debian-s3:v1.15.1-debian-s3-amd64-1.1,v1.15-debian-s3-amd64-1 \
+	v1.15/debian-syslog:v1.15.1-debian-syslog-amd64-1.1,v1.15-debian-syslog-amd64-1 \
+	v1.15/debian-forward:v1.15.1-debian-forward-amd64-1.1,v1.15-debian-forward-amd64-1 \
+	v1.15/debian-gcs:v1.15.1-debian-gcs-amd64-1.1,v1.15-debian-gcs-amd64-1 \
+	v1.15/debian-graylog:v1.15.1-debian-graylog-amd64-1.1,v1.15-debian-graylog-amd64-1 \
+	v1.15/debian-papertrail:v1.15.1-debian-papertrail-amd64-1.1,v1.15-debian-papertrail-amd64-1 \
+	v1.15/debian-logzio:v1.15.1-debian-logzio-amd64-1.1,v1.15-debian-logzio-amd64-1 \
+	v1.15/debian-kafka:v1.15.1-debian-kafka-amd64-1.1,v1.15-debian-kafka-amd64-1 \
+	v1.15/debian-kafka2:v1.15.1-debian-kafka2-amd64-1.1,v1.15-debian-kafka2-amd64-1 \
+	v1.15/debian-kinesis:v1.15.1-debian-kinesis-amd64-1.1,v1.15-debian-kinesis-amd64-1
 
 #	<Dockerfile>:<version>,<tag1>,<tag2>,...
 
 ARM64_IMAGES := \
-	v1.15/arm64/debian-azureblob:v1.15.1-debian-azureblob-arm64-1.0,v1.15-debian-azureblob-arm64-1 \
-	v1.15/arm64/debian-elasticsearch7:v1.15.1-debian-elasticsearch7-arm64-1.0,v1.15-debian-elasticsearch7-arm64-1,v1-debian-elasticsearch-arm64 \
-	v1.15/arm64/debian-elasticsearch6:v1.15.1-debian-elasticsearch6-arm64-1.0,v1.15-debian-elasticsearch6-arm64-1 \
-	v1.15/arm64/debian-opensearch:v1.15.1-debian-opensearch-arm64-1.0,v1.15-debian-opensearch-arm64-1 \
-	v1.15/arm64/debian-loggly:v1.15.1-debian-loggly-arm64-1.0,v1.15-debian-loggly-arm64-1 \
-	v1.15/arm64/debian-logentries:v1.15.1-debian-logentries-arm64-1.0,v1.15-debian-logentries-arm64-1 \
-	v1.15/arm64/debian-cloudwatch:v1.15.1-debian-cloudwatch-arm64-1.0,v1.15-debian-cloudwatch-arm64-1 \
-	v1.15/arm64/debian-stackdriver:v1.15.1-debian-stackdriver-arm64-1.0,v1.15-debian-stackdriver-arm64-1 \
-	v1.15/arm64/debian-s3:v1.15.1-debian-s3-arm64-1.0,v1.15-debian-s3-arm64-1 \
-	v1.15/arm64/debian-syslog:v1.15.1-debian-syslog-arm64-1.0,v1.15-debian-syslog-arm64-1 \
-	v1.15/arm64/debian-forward:v1.15.1-debian-forward-arm64-1.0,v1.15-debian-forward-arm64-1 \
-	v1.15/arm64/debian-gcs:v1.15.1-debian-gcs-arm64-1.0,v1.15-debian-gcs-arm64-1 \
-	v1.15/arm64/debian-graylog:v1.15.1-debian-graylog-arm64-1.0,v1.15-debian-graylog-arm64-1 \
-	v1.15/arm64/debian-papertrail:v1.15.1-debian-papertrail-arm64-1.0,v1.15-debian-papertrail-arm64-1 \
-	v1.15/arm64/debian-logzio:v1.15.1-debian-logzio-arm64-1.0,v1.15-debian-logzio-arm64-1 \
-	v1.15/arm64/debian-kafka:v1.15.1-debian-kafka-arm64-1.0,v1.15-debian-kafka-arm64-1 \
-	v1.15/arm64/debian-kafka2:v1.15.1-debian-kafka2-arm64-1.0,v1.15-debian-kafka2-arm64-1 \
-	v1.15/arm64/debian-kinesis:v1.15.1-debian-kinesis-arm64-1.0,v1.15-debian-kinesis-arm64-1
+	v1.15/arm64/debian-azureblob:v1.15.1-debian-azureblob-arm64-1.1,v1.15-debian-azureblob-arm64-1 \
+	v1.15/arm64/debian-elasticsearch7:v1.15.1-debian-elasticsearch7-arm64-1.1,v1.15-debian-elasticsearch7-arm64-1,v1-debian-elasticsearch-arm64 \
+	v1.15/arm64/debian-elasticsearch6:v1.15.1-debian-elasticsearch6-arm64-1.1,v1.15-debian-elasticsearch6-arm64-1 \
+	v1.15/arm64/debian-opensearch:v1.15.1-debian-opensearch-arm64-1.1,v1.15-debian-opensearch-arm64-1 \
+	v1.15/arm64/debian-loggly:v1.15.1-debian-loggly-arm64-1.1,v1.15-debian-loggly-arm64-1 \
+	v1.15/arm64/debian-logentries:v1.15.1-debian-logentries-arm64-1.1,v1.15-debian-logentries-arm64-1 \
+	v1.15/arm64/debian-cloudwatch:v1.15.1-debian-cloudwatch-arm64-1.1,v1.15-debian-cloudwatch-arm64-1 \
+	v1.15/arm64/debian-stackdriver:v1.15.1-debian-stackdriver-arm64-1.1,v1.15-debian-stackdriver-arm64-1 \
+	v1.15/arm64/debian-s3:v1.15.1-debian-s3-arm64-1.1,v1.15-debian-s3-arm64-1 \
+	v1.15/arm64/debian-syslog:v1.15.1-debian-syslog-arm64-1.1,v1.15-debian-syslog-arm64-1 \
+	v1.15/arm64/debian-forward:v1.15.1-debian-forward-arm64-1.1,v1.15-debian-forward-arm64-1 \
+	v1.15/arm64/debian-gcs:v1.15.1-debian-gcs-arm64-1.1,v1.15-debian-gcs-arm64-1 \
+	v1.15/arm64/debian-graylog:v1.15.1-debian-graylog-arm64-1.1,v1.15-debian-graylog-arm64-1 \
+	v1.15/arm64/debian-papertrail:v1.15.1-debian-papertrail-arm64-1.1,v1.15-debian-papertrail-arm64-1 \
+	v1.15/arm64/debian-logzio:v1.15.1-debian-logzio-arm64-1.1,v1.15-debian-logzio-arm64-1 \
+	v1.15/arm64/debian-kafka:v1.15.1-debian-kafka-arm64-1.1,v1.15-debian-kafka-arm64-1 \
+	v1.15/arm64/debian-kafka2:v1.15.1-debian-kafka2-arm64-1.1,v1.15-debian-kafka2-arm64-1 \
+	v1.15/arm64/debian-kinesis:v1.15.1-debian-kinesis-arm64-1.1,v1.15-debian-kinesis-arm64-1
 
 ALL_IMAGES := $(X86_IMAGES) $(ARM64_IMAGES)
 

--- a/README.md
+++ b/README.md
@@ -25,125 +25,125 @@ If you want to use above non published images, build it by yourself. Dockefile i
 
 ##### Multi-Arch images
 - `Azureblob`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-azureblob-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-azureblob-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-azureblob-1`
 - `Elasticsearch7`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-elasticsearch7-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-elasticsearch7-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-elasticsearch7-1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch`
 - `Opensearch`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-opensearch-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-opensearch-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-opensearch-1`
 - `Cloudwatch`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-cloudwatch-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-cloudwatch-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-cloudwatch-1`
 - `Forward`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-forward-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-forward-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-forward-1`
 - `Gcs`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-gcs-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-gcs-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-gcs-1`
 - `Graylog`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-graylog-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-graylog-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-graylog-1`
 - `Kafka`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kafka-1`
 - `Kafka2`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka2-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka2-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kafka2-1`
 - `Kinesis`
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kinesis-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kinesis-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kinesis-1`
 
 ##### x86_64 images
 - `Azureblob` [Dockerfile](docker-image/v1.15/debian-azureblob/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-azureblob-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-azureblob-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-azureblob-amd64-1`
 - `Elasticsearch7` [Dockerfile](docker-image/v1.15/debian-elasticsearch7/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-elasticsearch7-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-elasticsearch7-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-elasticsearch7-amd64-1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch-amd64`
 - `Elasticsearch6` [Dockerfile](docker-image/v1.15/debian-elasticsearch6/Dockerfile)
 - `Opensearch` [Dockerfile](docker-image/v1.15/debian-opensearch/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-opensearch-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-opensearch-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-opensearch-amd64-1`
 - `Loggly` [Dockerfile](docker-image/v1.15/debian-loggly/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-loggly-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-loggly-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-loggly-amd64-1`
 - `Logentries` [Dockerfile](docker-image/v1.15/debian-logentries/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-logentries-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-logentries-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-logentries-amd64-1`
 - `Cloudwatch` [Dockerfile](docker-image/v1.15/debian-cloudwatch/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-cloudwatch-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-cloudwatch-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-cloudwatch-amd64-1`
 - `Stackdriver` [Dockerfile](docker-image/v1.15/debian-stackdriver/Dockerfile)
 - `S3` [Dockerfile](docker-image/v1.15/debian-s3/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-s3-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-s3-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-s3-amd64-1`
 - `Syslog` [Dockerfile](docker-image/v1.15/debian-syslog/Dockerfile)
 - `Forward` [Dockerfile](docker-image/v1.15/debian-forward/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-forward-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-forward-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-forward-amd64-1`
 - `Gcs` [Dockerfile](docker-image/v1.15/debian-gcs/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-gcs-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-gcs-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-gcs-amd64-1`
 - `Graylog` [Dockerfile](docker-image/v1.15/debian-graylog/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-graylog-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-graylog-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-graylog-amd64-1`
 - `Papertrail` [Dockerfile](docker-image/v1.15/debian-papertrail/Dockerfile)
 - `Logzio` [Dockerfile](docker-image/v1.15/debian-logzio/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-logzio-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-logzio-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-logzio-amd64-1`
 - `Kafka` [Dockerfile](docker-image/v1.15/debian-kafka/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kafka-amd64-1`
 - `Kafka2` [Dockerfile](docker-image/v1.15/debian-kafka2/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka2-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka2-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kafka2-amd64-1`
 - `Kinesis` [Dockerfile](docker-image/v1.15/debian-kinesis/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kinesis-amd64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kinesis-amd64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kinesis-amd64-1`
 
 ##### arm64 images
 - `Azureblob` [Dockerfile](docker-image/v1.15/arm64/debian-azureblob/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-azureblob-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-azureblob-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-azureblob-arm64-1`
 - `Elasticsearch7` [Dockerfile](docker-image/v1.15/arm64/debian-elasticsearch7/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-elasticsearch7-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-elasticsearch7-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-elasticsearch7-arm64-1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1-debian-elasticsearch-arm64`
 - `Elasticsearch6` [Dockerfile](docker-image/v1.15/arm64/debian-elasticsearch6/Dockerfile)
 - `Opensearch` [Dockerfile](docker-image/v1.15/arm64/debian-opensearch/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-opensearch-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-opensearch-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-opensearch-arm64-1`
 - `Loggly` [Dockerfile](docker-image/v1.15/arm64/debian-loggly/Dockerfile)
 - `Logentries` [Dockerfile](docker-image/v1.15/arm64/debian-logentries/Dockerfile)
 - `Cloudwatch` [Dockerfile](docker-image/v1.15/arm64/debian-cloudwatch/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-cloudwatch-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-cloudwatch-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-cloudwatch-arm64-1`
 - `Stackdriver` [Dockerfile](docker-image/v1.15/arm64/debian-stackdriver/Dockerfile)
 - `S3` [Dockerfile](docker-image/v1.15/arm64/debian-s3/Dockerfile)
 - `Syslog` [Dockerfile](docker-image/v1.15/arm64/debian-syslog/Dockerfile)
 - `Forward` [Dockerfile](docker-image/v1.15/arm64/debian-forward/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-forward-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-forward-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-forward-arm64-1`
 - `Gcs` [Dockerfile](docker-image/v1.15/arm64/debian-gcs/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-gcs-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-gcs-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-gcs-arm64-1`
 - `Graylog` [Dockerfile](docker-image/v1.15/arm64/debian-graylog/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-graylog-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-graylog-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-graylog-arm64-1`
 - `Papertrail` [Dockerfile](docker-image/v1.15/arm64/debian-papertrail/Dockerfile)
 - `Logzio` [Dockerfile](docker-image/v1.15/arm64/debian-logzio/Dockerfile)
 - `Kafka` [Dockerfile](docker-image/v1.15/arm64/debian-kafka/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kafka-arm64-1`
 - `Kafka2` [Dockerfile](docker-image/v1.15/arm64/debian-kafka2/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka2-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kafka2-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kafka2-arm64-1`
 - `Kinesis` [Dockerfile](docker-image/v1.15/arm64/debian-kinesis/Dockerfile)
-  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kinesis-arm64-1.0`
+  - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15.1-debian-kinesis-arm64-1.1`
   - `docker pull fluent/fluentd-kubernetes-daemonset:v1.15-debian-kinesis-arm64-1`
 
 

--- a/docker-image/v1.15/arm64/debian-azureblob/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-azureblob/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-azureblob-arm64-1.0,v1.15-debian-azureblob-arm64-1}; do
+for tag in {v1.15.1-debian-azureblob-arm64-1.1,v1.15-debian-azureblob-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-cloudwatch/Gemfile.lock
+++ b/docker-image/v1.15/arm64/debian-cloudwatch/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-cloudwatchlogs (1.53.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)

--- a/docker-image/v1.15/arm64/debian-cloudwatch/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-cloudwatch/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-cloudwatch-arm64-1.0,v1.15-debian-cloudwatch-arm64-1}; do
+for tag in {v1.15.1-debian-cloudwatch-arm64-1.1,v1.15-debian-cloudwatch-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-elasticsearch6/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-elasticsearch6/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-elasticsearch6-arm64-1.0,v1.15-debian-elasticsearch6-arm64-1}; do
+for tag in {v1.15.1-debian-elasticsearch6-arm64-1.1,v1.15-debian-elasticsearch6-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-elasticsearch7/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-elasticsearch7/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-elasticsearch7-arm64-1.0,v1.15-debian-elasticsearch7-arm64-1,v1-debian-elasticsearch-arm64}; do
+for tag in {v1.15.1-debian-elasticsearch7-arm64-1.1,v1.15-debian-elasticsearch7-arm64-1,v1-debian-elasticsearch-arm64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-forward/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-forward/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-forward-arm64-1.0,v1.15-debian-forward-arm64-1}; do
+for tag in {v1.15.1-debian-forward-arm64-1.1,v1.15-debian-forward-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-gcs/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-gcs/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-gcs-arm64-1.0,v1.15-debian-gcs-arm64-1}; do
+for tag in {v1.15.1-debian-gcs-arm64-1.1,v1.15-debian-gcs-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-graylog/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-graylog/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-graylog-arm64-1.0,v1.15-debian-graylog-arm64-1}; do
+for tag in {v1.15.1-debian-graylog-arm64-1.1,v1.15-debian-graylog-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-kafka/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-kafka/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-kafka-arm64-1.0,v1.15-debian-kafka-arm64-1}; do
+for tag in {v1.15.1-debian-kafka-arm64-1.1,v1.15-debian-kafka-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-kafka2/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-kafka2/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-kafka2-arm64-1.0,v1.15-debian-kafka2-arm64-1}; do
+for tag in {v1.15.1-debian-kafka2-arm64-1.1,v1.15-debian-kafka2-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-kinesis/Gemfile.lock
+++ b/docker-image/v1.15/arm64/debian-kinesis/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-core (3.131.5)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)

--- a/docker-image/v1.15/arm64/debian-kinesis/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-kinesis/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-kinesis-arm64-1.0,v1.15-debian-kinesis-arm64-1}; do
+for tag in {v1.15.1-debian-kinesis-arm64-1.1,v1.15-debian-kinesis-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-logentries/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-logentries/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-logentries-arm64-1.0,v1.15-debian-logentries-arm64-1}; do
+for tag in {v1.15.1-debian-logentries-arm64-1.1,v1.15-debian-logentries-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-loggly/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-loggly/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-loggly-arm64-1.0,v1.15-debian-loggly-arm64-1}; do
+for tag in {v1.15.1-debian-loggly-arm64-1.1,v1.15-debian-loggly-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-logzio/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-logzio/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-logzio-arm64-1.0,v1.15-debian-logzio-arm64-1}; do
+for tag in {v1.15.1-debian-logzio-arm64-1.1,v1.15-debian-logzio-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-opensearch/Gemfile.lock
+++ b/docker-image/v1.15/arm64/debian-opensearch/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-core (3.131.5)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)

--- a/docker-image/v1.15/arm64/debian-opensearch/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-opensearch/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-opensearch-arm64-1.0,v1.15-debian-opensearch-arm64-1}; do
+for tag in {v1.15.1-debian-opensearch-arm64-1.1,v1.15-debian-opensearch-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-papertrail/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-papertrail/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-papertrail-arm64-1.0,v1.15-debian-papertrail-arm64-1}; do
+for tag in {v1.15.1-debian-papertrail-arm64-1.1,v1.15-debian-papertrail-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-s3/Gemfile.lock
+++ b/docker-image/v1.15/arm64/debian-s3/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-core (3.131.5)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)

--- a/docker-image/v1.15/arm64/debian-s3/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-s3/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-s3-arm64-1.0,v1.15-debian-s3-arm64-1}; do
+for tag in {v1.15.1-debian-s3-arm64-1.1,v1.15-debian-s3-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-stackdriver/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-stackdriver/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-stackdriver-arm64-1.0,v1.15-debian-stackdriver-arm64-1}; do
+for tag in {v1.15.1-debian-stackdriver-arm64-1.1,v1.15-debian-stackdriver-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/arm64/debian-syslog/hooks/post_push
+++ b/docker-image/v1.15/arm64/debian-syslog/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-syslog-arm64-1.0,v1.15-debian-syslog-arm64-1}; do
+for tag in {v1.15.1-debian-syslog-arm64-1.1,v1.15-debian-syslog-arm64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-azureblob/hooks/post_push
+++ b/docker-image/v1.15/debian-azureblob/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-azureblob-amd64-1.0,v1.15-debian-azureblob-amd64-1}; do
+for tag in {v1.15.1-debian-azureblob-amd64-1.1,v1.15-debian-azureblob-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-cloudwatch/Gemfile.lock
+++ b/docker-image/v1.15/debian-cloudwatch/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-cloudwatchlogs (1.53.0)
       aws-sdk-core (~> 3, >= 3.127.0)
       aws-sigv4 (~> 1.1)

--- a/docker-image/v1.15/debian-cloudwatch/hooks/post_push
+++ b/docker-image/v1.15/debian-cloudwatch/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-cloudwatch-amd64-1.0,v1.15-debian-cloudwatch-amd64-1}; do
+for tag in {v1.15.1-debian-cloudwatch-amd64-1.1,v1.15-debian-cloudwatch-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-elasticsearch6/hooks/post_push
+++ b/docker-image/v1.15/debian-elasticsearch6/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-elasticsearch6-amd64-1.0,v1.15-debian-elasticsearch6-amd64-1}; do
+for tag in {v1.15.1-debian-elasticsearch6-amd64-1.1,v1.15-debian-elasticsearch6-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-elasticsearch7/hooks/post_push
+++ b/docker-image/v1.15/debian-elasticsearch7/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-elasticsearch7-amd64-1.0,v1.15-debian-elasticsearch7-amd64-1,v1-debian-elasticsearch-amd64}; do
+for tag in {v1.15.1-debian-elasticsearch7-amd64-1.1,v1.15-debian-elasticsearch7-amd64-1,v1-debian-elasticsearch-amd64}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-forward/hooks/post_push
+++ b/docker-image/v1.15/debian-forward/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-forward-amd64-1.0,v1.15-debian-forward-amd64-1}; do
+for tag in {v1.15.1-debian-forward-amd64-1.1,v1.15-debian-forward-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-gcs/hooks/post_push
+++ b/docker-image/v1.15/debian-gcs/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-gcs-amd64-1.0,v1.15-debian-gcs-amd64-1}; do
+for tag in {v1.15.1-debian-gcs-amd64-1.1,v1.15-debian-gcs-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-graylog/hooks/post_push
+++ b/docker-image/v1.15/debian-graylog/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-graylog-amd64-1.0,v1.15-debian-graylog-amd64-1}; do
+for tag in {v1.15.1-debian-graylog-amd64-1.1,v1.15-debian-graylog-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-kafka/hooks/post_push
+++ b/docker-image/v1.15/debian-kafka/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-kafka-amd64-1.0,v1.15-debian-kafka-amd64-1}; do
+for tag in {v1.15.1-debian-kafka-amd64-1.1,v1.15-debian-kafka-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-kafka2/hooks/post_push
+++ b/docker-image/v1.15/debian-kafka2/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-kafka2-amd64-1.0,v1.15-debian-kafka2-amd64-1}; do
+for tag in {v1.15.1-debian-kafka2-amd64-1.1,v1.15-debian-kafka2-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-kinesis/Gemfile.lock
+++ b/docker-image/v1.15/debian-kinesis/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-core (3.131.5)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)

--- a/docker-image/v1.15/debian-kinesis/hooks/post_push
+++ b/docker-image/v1.15/debian-kinesis/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-kinesis-amd64-1.0,v1.15-debian-kinesis-amd64-1}; do
+for tag in {v1.15.1-debian-kinesis-amd64-1.1,v1.15-debian-kinesis-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-logentries/hooks/post_push
+++ b/docker-image/v1.15/debian-logentries/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-logentries-amd64-1.0,v1.15-debian-logentries-amd64-1}; do
+for tag in {v1.15.1-debian-logentries-amd64-1.1,v1.15-debian-logentries-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-loggly/hooks/post_push
+++ b/docker-image/v1.15/debian-loggly/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-loggly-amd64-1.0,v1.15-debian-loggly-amd64-1}; do
+for tag in {v1.15.1-debian-loggly-amd64-1.1,v1.15-debian-loggly-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-logzio/hooks/post_push
+++ b/docker-image/v1.15/debian-logzio/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-logzio-amd64-1.0,v1.15-debian-logzio-amd64-1}; do
+for tag in {v1.15.1-debian-logzio-amd64-1.1,v1.15-debian-logzio-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-opensearch/Gemfile.lock
+++ b/docker-image/v1.15/debian-opensearch/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-core (3.131.5)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)

--- a/docker-image/v1.15/debian-opensearch/hooks/post_push
+++ b/docker-image/v1.15/debian-opensearch/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-opensearch-amd64-1.0,v1.15-debian-opensearch-amd64-1}; do
+for tag in {v1.15.1-debian-opensearch-amd64-1.1,v1.15-debian-opensearch-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-papertrail/hooks/post_push
+++ b/docker-image/v1.15/debian-papertrail/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-papertrail-amd64-1.0,v1.15-debian-papertrail-amd64-1}; do
+for tag in {v1.15.1-debian-papertrail-amd64-1.1,v1.15-debian-papertrail-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-s3/Gemfile.lock
+++ b/docker-image/v1.15/debian-s3/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.613.0)
+    aws-partitions (1.614.0)
     aws-sdk-core (3.131.5)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.525.0)

--- a/docker-image/v1.15/debian-s3/hooks/post_push
+++ b/docker-image/v1.15/debian-s3/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-s3-amd64-1.0,v1.15-debian-s3-amd64-1}; do
+for tag in {v1.15.1-debian-s3-amd64-1.1,v1.15-debian-s3-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-stackdriver/hooks/post_push
+++ b/docker-image/v1.15/debian-stackdriver/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-stackdriver-amd64-1.0,v1.15-debian-stackdriver-amd64-1}; do
+for tag in {v1.15.1-debian-stackdriver-amd64-1.1,v1.15-debian-stackdriver-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed

--- a/docker-image/v1.15/debian-syslog/hooks/post_push
+++ b/docker-image/v1.15/debian-syslog/hooks/post_push
@@ -13,7 +13,7 @@ curl -Lo manifest-tool https://github.com/estesp/manifest-tool/releases/download
 chmod +x manifest-tool
 
 # Tag and push image and manifest list for each additional tag
-for tag in {v1.15.1-debian-syslog-amd64-1.0,v1.15-debian-syslog-amd64-1}; do
+for tag in {v1.15.1-debian-syslog-amd64-1.1,v1.15-debian-syslog-amd64-1}; do
   docker tag $IMAGE_NAME ${repoName}:${tag}
   docker push ${repoName}:${tag}
   # Note: this will fail until both the amd64 and arm64 images have been pushed


### PR DESCRIPTION
The base fluent/fluentd docker image for v1.15.1-1.0 include async v2 gem but fluentd isn't ready for it. To avoid using it, rebuild images with fluent/flunetd:v1.15.1-1.1.
