### PR TITLE
fluent-plugin-gcs updated to 0.4.2

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -44,7 +44,7 @@ gem "fluent-plugin-azure-storage-append-blob-lts", "~> 0.6.0"
 gem "aws-sdk-s3", "~> 1.101"
 gem "fluent-plugin-s3", "~> 1.7.0"
 <% when "gcs" %>
-gem "fluent-plugin-gcs", "0.4.1"
+gem "fluent-plugin-gcs", "0.4.2"
 <% when "graylog" %>
 gem "gelf", "3.0.0"
 gem "fluent-plugin-gelf-hs", "~> 1.0.7"


### PR DESCRIPTION
`fluent-plugin-gcs` version `0.4.1` (used by those images) had a [bug](https://github.com/daichirata/fluent-plugin-gcs/issues/21) that made it unusable when uploading logs to GCS. The bug have been [fixed](fluent-plugin-gcs) in `0.4.2`.

This change updates the plugin version to `0.4.2`, so uploading logs to GCS is again possible.