### PR TITLE
fix elastic templates so that tail log parser works and daemonsets dont crash

### DIFF
--- a/fluentd-daemonset-elasticsearch-rbac.yaml
+++ b/fluentd-daemonset-elasticsearch-rbac.yaml
@@ -89,6 +89,12 @@ spec:
             value: "elastic"
           - name: FLUENT_ELASTICSEARCH_PASSWORD
             value: "changeme"
+          # Prevents circular logging issue
+          - name: FLUENT_CONTAINER_TAIL_EXCLUDE_PATH
+            value: /var/log/containers/fluent*
+          # Docker log parser
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+            value: /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
         resources:
           limits:
             memory: 200Mi

--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -56,6 +56,12 @@ spec:
             value: "ThisIsASuperLongToken"
           - name: LOGZIO_LOGTYPE
             value: "kubernetes"
+          # Prevents circular logging issue
+          - name: FLUENT_CONTAINER_TAIL_EXCLUDE_PATH
+            value: /var/log/containers/fluent*
+          # Docker log parser
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+            value: /^(?<time>.+) (?<stream>stdout|stderr)( (?<logtag>.))? (?<log>.*)$/
         resources:
           limits:
             memory: 200Mi


### PR DESCRIPTION
This fix provides 2 updates to the elastic daemonsets.

1. Solves an issue where there was an infinite loop because fluent logs were being exported to elastic which would create fluent entries...  and daemonsets were tending to crash.

2. Solves an issue where tail parser was not working because it did not have a parser associated. I have added a parser to parse docker style log entries as that's what most people are using, however if you are using something else it would be quite clear for a user to see how to modify it.

This is documented here (as well as other various github issues which appears to trip a lot of people up). https://github.com/fluent/fluentd-kubernetes-daemonset/issues/434