### PR TITLE
Update fluent-plugin-logzio gem to v0.2.2

### DIFF
--- a/templates/Gemfile.erb
+++ b/templates/Gemfile.erb
@@ -53,7 +53,7 @@ gem "fluent-plugin-gcs", "0.4.2"
 gem "gelf", "3.0.0"
 gem "fluent-plugin-gelf-hs", "~> 1.0.7"
 <% when "logzio" %>
-gem "fluent-plugin-logzio", "~> 0.2.0"
+gem "fluent-plugin-logzio", "~> 0.2.2"
 <% when "papertrail" %>
 gem "fluent-plugin-papertrail", "~> 0.2.6"
 <% when "syslog" %>


### PR DESCRIPTION
Fixes #1457 by upgrading the fluent-plugin-logzio gem to v0.2.2 as this fixes the Prometheus gem dependency issue.