### PR TITLE
Improve doc for containerd/cri-o setup

### DIFF
--- a/fluentd-daemonset-elasticsearch-rbac.yaml
+++ b/fluentd-daemonset-elasticsearch-rbac.yaml
@@ -89,6 +89,24 @@ spec:
             value: "elastic"
           - name: FLUENT_ELASTICSEARCH_PASSWORD
             value: "changeme"
+          # Exclude Fluentd logs' to avoid an infine loop
+          # ================================================================
+          - name: FLUENT_CONTAINER_TAIL_EXCLUDE_PATH
+            value: "/var/log/pods/fluent*"
+          # Option to configure containerd/cri-o log format
+          # ================================================================
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+            value: "cri"
+          # Option to configure containerd date time log format
+          # ================================================================
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT
+            value: "%Y-%m-%dT%H:%M:%S.%N%:z"
+          # Logz.io Authentication
+          # ======================
+          - name: LOGZIO_TOKEN
+            value: "ThisIsASuperLongToken"
+          - name: LOGZIO_LOGTYPE
+            value: "kubernetes"
         resources:
           limits:
             memory: 200Mi

--- a/fluentd-daemonset-elasticsearch.yaml
+++ b/fluentd-daemonset-elasticsearch.yaml
@@ -50,6 +50,18 @@ spec:
             value: "elastic"
           - name: FLUENT_ELASTICSEARCH_PASSWORD
             value: "changeme"
+          # Exclude Fluentd logs' to avoid an infine loop
+          # ================================================================
+          - name: FLUENT_CONTAINER_TAIL_EXCLUDE_PATH
+            value: "/var/log/pods/fluent*"
+          # Option to configure containerd/cri-o log format
+          # ================================================================
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+            value: "cri"
+          # Option to configure containerd date time log format
+          # ================================================================
+          - name: FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT
+            value: "%Y-%m-%dT%H:%M:%S.%N%:z"
           # Logz.io Authentication
           # ======================
           - name: LOGZIO_TOKEN

--- a/fluentd-daemonset-opensearch.yaml
+++ b/fluentd-daemonset-opensearch.yaml
@@ -60,10 +60,16 @@ spec:
             value: "/path/to/file.key"
           - name: FLUENT_OPENSEARCH_CLIENT_KEY_PASS
             value: "changeme"
-          # Fluentd Parser
-          # =====================
+          # Exclude Fluentd logs' to avoid an infine loop
+          # ================================================================
+          - name: FLUENT_CONTAINER_TAIL_EXCLUDE_PATH
+            value: "/var/log/pods/fluent*"
+          # Option to configure containerd/cri-o log format
+          # ================================================================
           - name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
             value: "cri"
+          # Option to configure containerd date time log format
+          # ================================================================
           - name: FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT
             value: "%Y-%m-%dT%H:%M:%S.%N%:z"
         resources:

--- a/templates/README.md.erb
+++ b/templates/README.md.erb
@@ -167,6 +167,14 @@ You can use `cri` parser by overwriting `tail_container_parse.conf` via ConfigMa
 </parse>
 ```
 
+Or by setting environment variables `FLUENT_CONTAINER_TAIL_PARSER_TYPE` and/or `FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT` according to your setup.
+```
+- name: FLUENT_CONTAINER_TAIL_PARSER_TYPE
+  value: "cri"
+- name: FLUENT_CONTAINER_TAIL_PARSER_TIME_FORMAT
+  value: "%Y-%m-%dT%H:%M:%S.%N%:z"
+```
+
 See also [CRI parser README](https://github.com/fluent/fluent-plugin-parser-cri#log-and-configuration-example)
 
 ### Use FLUENT_CONTAINER_TAIL_PATH to change container logs folder


### PR DESCRIPTION
Hi,

I have just started to deploy EFK for an internal K3S in my company.
We meet issues like:
* `[in_tail_container_logs] pattern not matched`;
* `[in_tail_container_logs] *** invalid time format`.

These issues are known as #434 and #571 and deserve a better documentation for developers. I spent around 2hours yesterday to read/understand/test.
That's why I propose this PR to update README.md and Elastic/OS examples.