### PR TITLE
github: use only tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,8 +2,6 @@ name: Publish Docker Image
 
 on:
   push:
-    branches:
-      - master
     tags:
       - v1.*
 


### PR DESCRIPTION
Both of branches and tags are specified, either branches or tags are pushed, GitHub Actions are triggered.

In practical use-case, after some PRs has merged, we want to release it.
Thus it is enough to specify tags.