### PR TITLE
Fix incorrect environment name

### DIFF
--- a/fluentd-daemonset-forward.yaml
+++ b/fluentd-daemonset-forward.yaml
@@ -30,9 +30,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: spec.nodeName
-          - name:  FLUENT_FOWARD_HOST
+          - name:  FLUENT_FORWARD_HOST
             value: "REMOTE_ENDPOINT"
-          - name:  FLUENT_FOWARD_PORT
+          - name:  FLUENT_FORWARD_PORT
             value: "18080"
         resources:
           limits:

--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -375,8 +375,8 @@
   @id out_fwd
   @log_level info
   <server>
-    host "#{ENV['FLUENT_FOWARD_HOST']}"
-    port "#{ENV['FLUENT_FOWARD_PORT']}"
+    host "#{ENV['FLUENT_FORWARD_HOST'] || ENV['FLUENT_FOWARD_HOST']}"
+    port "#{ENV['FLUENT_FORWARD_PORT'] || ENV['FLUENT_FOWARD_PORT']}"
   </server>
   <buffer>
     flush_interval "#{ENV['FLUENT_FORWARD_FLUSH_INTERVAL'] || use_default}"


### PR DESCRIPTION
It is a long standing typo.

Closes: #1383