### PR TITLE
Change jemalloc opt-in for now

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -72,6 +72,9 @@ COPY entrypoint.sh /fluentd/entrypoint.sh
 # Environment variables
 ENV FLUENTD_OPT=""
 ENV FLUENTD_CONF="fluent.conf"
+# Override LD_PRELOAD in fluentd docker image
+# Set "/usr/lib/libjemalloc.so.2" if you want to enable jemalloc explicitly
+ENV LD_PRELOAD=""
 
 # Overwrite ENTRYPOINT to run fluentd as root for /var/log / /var/lib
 ENTRYPOINT ["tini", "--", "/fluentd/entrypoint.sh"]


### PR DESCRIPTION
There is a known bug that combination with jemalloc and fluent-plugin-systemd causes free(): invalid crash for a long time. The problematic code is identified but the root cause is not fixed yet.

There is a workaround for this - disable jemalloc explicitly. LD_PRELOAD= stop to use jemalloc.

If you want to use jemalloc, set it via env like this:

```
 containers:
   - name: fluentd image: fluent/fluentd-kubernetes-daemonset:v1-debian-forward
   -  env:
     ...
     - name:  LD_PRELOAD
       value: "/usr/lib/libjemalloc.so.2"
```

Related issues:

* https://github.com/fluent/fluentd-docker-image/issues/378
* https://github.com/fluent/fluent-package-builder/issues/369
* https://github.com/fluent-plugins-nursery/fluent-plugin-systemd/issues/110
* https://github.com/ledbettj/systemd-journal/issues/93
* https://github.com/fluent/fluentd-kubernetes-daemonset/issues/1478