### PR TITLE
Backport: fix failure on IPv6 single stack cluster

### DIFF
--- a/templates/conf/kubernetes.conf.erb
+++ b/templates/conf/kubernetes.conf.erb
@@ -28,7 +28,7 @@
 <filter kubernetes.**>
   @type kubernetes_metadata
   @id filter_kube_metadata
-  kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || 'https://' + ENV.fetch('KUBERNETES_SERVICE_HOST') + ':' + ENV.fetch('KUBERNETES_SERVICE_PORT') + '/api'}"
+  kubernetes_url "#{ENV['FLUENT_FILTER_KUBERNETES_URL'] || (host = ENV.fetch('KUBERNETES_SERVICE_HOST'); port = ENV.fetch('KUBERNETES_SERVICE_PORT'); host = (IPAddr.new(host).ipv6? ? '[' + host + ']' : host rescue host); 'https://' + host + ':' + port + '/api')}"
   verify_ssl "#{ENV['KUBERNETES_VERIFY_SSL'] || true}"
   ca_file "#{ENV['KUBERNETES_CA_FILE']}"
   skip_labels "#{ENV['FLUENT_KUBERNETES_METADATA_SKIP_LABELS'] || 'false'}"


### PR DESCRIPTION
When FLUENT_FILTER_KUBERNETES_URL is not set, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT are used as a fallback.

When applying such a fallback, it will fail on only IPv6 is available. It causes the following error:

  /usr/local/lib/ruby/3.2.0/uri/rfc3986_parser.rb:66:in `split': bad
  URI(is not URI?):
  "https://IPV6_ADDRESS:443/api" (URI::InvalidURIError)

IPv6 address must be enclosed with square brackets.

Closes: #1546