### PR TITLE
Backport(v1.16) papertrail: add CRI parser fallback (#1541)

### DIFF
--- a/templates/conf/kubernetes.conf.erb
+++ b/templates/conf/kubernetes.conf.erb
@@ -61,7 +61,7 @@
     program ${record["kubernetes"]["container_name"]}
     severity info
     facility local0
-    message ${record['log']}
+    message ${record['log'] || record['message']}
   </record>
 </filter>
 <% end %>


### PR DESCRIPTION
Closes: #1537

When parser is replaced to CRI parser in tail_container_parse.conf, parsed output stored into message not log.
As a result, blank message will be omitted.