### PR TITLE
Backport(v1.16) Add OpenSearch sniffer class name and use it by default (#1544)

### DIFF
--- a/templates/conf/fluent.conf.erb
+++ b/templates/conf/fluent.conf.erb
@@ -82,6 +82,7 @@
   logstash_format "#{ENV['FLUENT_OPENSEARCH_LOGSTASH_FORMAT'] || 'false'}"
   logstash_prefix "#{ENV['FLUENT_OPENSEARCH_LOGSTASH_PREFIX'] || 'logstash'}"
   logstash_prefix_separator "#{ENV['FLUENT_OPENSEARCH_LOGSTASH_PREFIX_SEPARATOR'] || '-'}"
+  sniffer_class_name "#{ENV['FLUENT_OPENSEARCH_SNIFFER_CLASS_NAME'] || 'Fluent::Plugin::OpenSearchSimpleSniffer'}"
   <buffer>
     flush_thread_count "#{ENV['FLUENT_OPENSEARCH_BUFFER_FLUSH_THREAD_COUNT'] || '1'}"
     flush_mode "#{ENV['FLUENT_OPENSEARCH_BUFFER_FLUSH_MODE'] || 'interval'}"

--- a/templates/entrypoint.sh.erb
+++ b/templates/entrypoint.sh.erb
@@ -15,5 +15,16 @@ if [ -n "$SIMPLE_SNIFFER" -a -f "$SIMPLE_SNIFFER" ] ; then
 fi
 
 <% end %>
+<% if target == "opensearch" %>
+
+set -e
+
+SIMPLE_SNIFFER=$( gem contents fluent-plugin-opensearch | grep opensearch_simple_sniffer.rb )
+
+if [ -n "$SIMPLE_SNIFFER" -a -f "$SIMPLE_SNIFFER" ] ; then
+    FLUENTD_OPT="$FLUENTD_OPT -r $SIMPLE_SNIFFER"
+fi
+
+<% end %>
 
 exec fluentd -c /fluentd/etc/${FLUENTD_CONF} -p /fluentd/plugins --gemfile /fluentd/Gemfile ${FLUENTD_OPT}


### PR DESCRIPTION
The same done for Elasticsearch at https://github.com/fluent/fluentd-kubernetes-daemonset/pull/403, but now for OpenSearch.

Both Elasticsearch/Opensearch Sniffer class works the same way, need to be added to fluentd entrypoint https://github.com/fluent/fluent-plugin-opensearch?tab=readme-ov-file#tips.

It is required when fluentd don't connect directly to Opensearch servers, but connect to a proxy or load balancer in front of Opensearch servers.

Signed-off-by: Sergio López <slopezma@redhat.com>