### PR TITLE
Omit suffix to follow the latest image

### DIFF
--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -7,9 +7,9 @@
 
 <% if is_arm64 %>
 # For multiarch build on Docker hub automated build.
-FROM fluent/fluentd:<%= fluentd_ver %>-debian-arm64-1.0
+FROM fluent/fluentd:<%= fluentd_ver %>-debian-arm64
 <% else %>
-FROM fluent/fluentd:<%= fluentd_ver %>-debian-amd64-1.0
+FROM fluent/fluentd:<%= fluentd_ver %>-debian-amd64
 <% end %>
 
 LABEL maintainer="Eduardo Silva <eduardo@treasure-data.com>"


### PR DESCRIPTION
New tagging rule makes easy to track latest one.
See fluent/fluentd-docker-image#431