### PR TITLE
Remove unnecessary bundler installation

### DIFF
--- a/docker-image/v1.19/arm64/debian-azureblob/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-azureblob/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true && bundle config build.nokogiri --use-system-libraries \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-cloudwatch/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-cloudwatch/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-datadog/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-datadog/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-elasticsearch7/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-elasticsearch7/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-elasticsearch8/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-elasticsearch8/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-forward/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-forward/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-gcs/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-gcs/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-graylog/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-graylog/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential patch zlib1
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-kafka/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-kafka/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-kafka2/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-kafka2/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-kinesis/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-kinesis/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-logentries/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-logentries/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-loggly/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-loggly/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-logzio/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-logzio/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-opensearch/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-opensearch/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-papertrail/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-papertrail/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/arm64/debian-s3/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-s3/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev curl" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && curl -sL -o columnify_0.1.0_Linux_x86_64.tar.gz https://github.com/reproio/columnify/releases/download/v0.1.0/columnify_0.1.0_Linux_x86_64.tar.gz \

--- a/docker-image/v1.19/arm64/debian-syslog/Dockerfile
+++ b/docker-image/v1.19/arm64/debian-syslog/Dockerfile
@@ -21,7 +21,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-azureblob/Dockerfile
+++ b/docker-image/v1.19/debian-azureblob/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true && bundle config build.nokogiri --use-system-libraries \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-cloudwatch/Dockerfile
+++ b/docker-image/v1.19/debian-cloudwatch/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-datadog/Dockerfile
+++ b/docker-image/v1.19/debian-datadog/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-elasticsearch7/Dockerfile
+++ b/docker-image/v1.19/debian-elasticsearch7/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-elasticsearch8/Dockerfile
+++ b/docker-image/v1.19/debian-elasticsearch8/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-forward/Dockerfile
+++ b/docker-image/v1.19/debian-forward/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-gcs/Dockerfile
+++ b/docker-image/v1.19/debian-gcs/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-graylog/Dockerfile
+++ b/docker-image/v1.19/debian-graylog/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential patch zlib1
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-kafka/Dockerfile
+++ b/docker-image/v1.19/debian-kafka/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-kafka2/Dockerfile
+++ b/docker-image/v1.19/debian-kafka2/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev build-essential autoconf au
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-kinesis/Dockerfile
+++ b/docker-image/v1.19/debian-kinesis/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-logentries/Dockerfile
+++ b/docker-image/v1.19/debian-logentries/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-loggly/Dockerfile
+++ b/docker-image/v1.19/debian-loggly/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-logzio/Dockerfile
+++ b/docker-image/v1.19/debian-logzio/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-opensearch/Dockerfile
+++ b/docker-image/v1.19/debian-opensearch/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-papertrail/Dockerfile
+++ b/docker-image/v1.19/debian-papertrail/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/docker-image/v1.19/debian-s3/Dockerfile
+++ b/docker-image/v1.19/debian-s3/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev curl" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && curl -sL -o columnify_0.1.0_Linux_x86_64.tar.gz https://github.com/reproio/columnify/releases/download/v0.1.0/columnify_0.1.0_Linux_x86_64.tar.gz \

--- a/docker-image/v1.19/debian-syslog/Dockerfile
+++ b/docker-image/v1.19/debian-syslog/Dockerfile
@@ -20,7 +20,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev" \
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
     && SUDO_FORCE_REMOVE=yes \

--- a/templates/Dockerfile.erb
+++ b/templates/Dockerfile.erb
@@ -29,7 +29,6 @@ RUN buildDeps="sudo make gcc g++ libc-dev libffi-dev<% if target == "graylog" %>
      && apt-get install \
      -y --no-install-recommends \
      $buildDeps $runtimeDeps net-tools \
-    && gem install bundler --version 2.4.17 \
     && bundle config silence_root_warning true<% if target == "azureblob" %> && bundle config build.nokogiri --use-system-libraries<% end %> \
     && bundle install --gemfile=/fluentd/Gemfile --path=/fluentd/vendor/bundle \
 <% if target == "s3" %>


### PR DESCRIPTION
Ruby 3.4 has bundled `bundler`.

```
$ docker run -it --rm fluent/fluentd:v1.19.1-debian-amd64 bundle --version
Bundler version 2.6.9
```

We have installed a version older than that, but older versions won't be used unless we explicitly specify a version with `bundle _2.4.17_`.

And it is unused.