### PR TITLE
Replace imagelayers.io to docker/image-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 
 [![Docker Stars](https://img.shields.io/docker/stars/fluent/fluentd-kubernetes-daemonset.svg)](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset)
 [![Docker Pulls](https://img.shields.io/docker/pulls/fluent/fluentd-kubernetes-daemonset.svg)](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset)
-[![ImageLayers Size](https://img.shields.io/imagelayers/image-size/fluent/fluentd-kubernetes-daemonset/latest.svg)](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset)
-[![ImageLayers Layers](https://img.shields.io/imagelayers/layers/fluent/fluentd-kubernetes-daemonset/latest.svg)](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset)
+[![Docker Image Size](https://img.shields.io/docker/image-size/fluent/fluentd-kubernetes-daemonset)](https://hub.docker.com/r/fluent/fluentd-kubernetes-daemonset)
 
 ## Supported tags and respective `Dockerfile` links
 


### PR DESCRIPTION
No support for imagelayers.io on shields.io.