### PR TITLE
Fix ignore pattern

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     groups:
       # PR: "Security update [package] from [old] to [new]"
       # This PR should be merged in hurry
@@ -41,9 +41,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -59,9 +56,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -77,9 +71,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -95,9 +86,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -113,9 +101,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -131,9 +116,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -149,9 +131,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -167,9 +146,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -185,9 +161,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -203,9 +176,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -221,9 +191,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -239,9 +206,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -257,9 +221,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -275,9 +236,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -293,9 +251,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -311,9 +266,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -329,9 +281,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -347,9 +296,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -365,9 +311,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -383,9 +326,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -401,9 +341,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -419,9 +356,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -437,9 +371,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -455,9 +386,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -473,9 +401,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -491,9 +416,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -509,9 +431,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -527,9 +446,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -545,9 +461,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -563,9 +476,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -581,9 +491,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -599,9 +506,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -617,9 +521,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -635,9 +536,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -653,9 +551,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.
@@ -671,9 +566,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.

--- a/templates/dependabot.yml.erb
+++ b/templates/dependabot.yml.erb
@@ -11,7 +11,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     groups:
       # PR: "Security update [package] from [old] to [new]"
       # This PR should be merged in hurry
@@ -44,9 +44,6 @@ updates:
         applies-to: security-updates
         patterns:
           - "*"
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update"]
     # Check [Security and quality] or [Insights] > [Dependency graph]
     # periodically It will help to know security issues in each
     # Gemfile, but no need to create PR automatically.


### PR DESCRIPTION
Drop useless ignore and relax actions interval

update-types accepts version-update:semver-major,
     version-update:semver-minor, version-update:semver-patch, but
     none of them is specified. It seems that it breaks monthly-update for
     github actions. (guess)

ref. https://docs.github.com/code-security/reference/supply-chain-security/dependabot-options-reference#ignore

